### PR TITLE
feat(main): VovkInput type that combines body, query, params

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -377,6 +377,7 @@ import {
   type VovkBody,
   type VovkQuery,
   type VovkParams,
+  type VovkInput, // combined { params, query, body }
   type VovkOutput,
   type VovkClientBody,
   type VovkClientQuery,

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ const { tools } = deriveTools({ modules: { UserRPC, TaskController, PetstoreAPI 
 console.log(tools); // [{ name, description, parameters, execute }, ...]
 ```
 
-Procedures can be executed locally for SSR/PPR:
+Procedures can be executed locally for SSR/PPR and server actions:
 
 ```ts
 await UserController.getUser.fn({ params: { id: '123' } });

--- a/packages/vovk-cli/src/init/updateTypeScriptConfig.mts
+++ b/packages/vovk-cli/src/init/updateTypeScriptConfig.mts
@@ -3,10 +3,7 @@ import fs from 'node:fs/promises';
 import * as jsonc from 'jsonc-parser';
 import { prettify } from '../utils/prettify.mjs';
 
-export async function updateTypeScriptConfig(
-  root: string,
-  compilerOptions: { experimentalDecorators?: true; }
-) {
+export async function updateTypeScriptConfig(root: string, compilerOptions: { experimentalDecorators?: true }) {
   const tsconfigPath = path.join(root, 'tsconfig.json');
   const tsconfigContent = await fs.readFile(tsconfigPath, 'utf8');
 

--- a/packages/vovk/src/index.ts
+++ b/packages/vovk/src/index.ts
@@ -31,6 +31,7 @@ export type {
   VovkBody,
   VovkQuery,
   VovkParams,
+  VovkInput,
   VovkReturnType,
   VovkYieldType,
   VovkOutput,

--- a/packages/vovk/src/types/inference.ts
+++ b/packages/vovk/src/types/inference.ts
@@ -133,6 +133,29 @@ export type VovkYieldType<T extends (...args: KnownAny[]) => unknown> = T extend
   ? VovkClientYieldType<T>
   : VovkControllerYieldType<T>;
 
+type _VovkInputRaw<T extends (...args: KnownAny[]) => unknown> = {
+  params: VovkParams<T>;
+  query: VovkQuery<T>;
+  body: VovkBody<T>;
+};
+
+type _OmitUndefinedOrUnknown<T> = {
+  [K in keyof T as unknown extends T[K] ? never : [T[K]] extends [undefined] ? never : K]: T[K];
+};
+
+/**
+ * Utility type to extract the full input (params, query, body) from both controller and client methods.
+ * Only includes properties that are actually defined — omits keys whose types resolve to `undefined` or `unknown`.
+ * Useful for Next.js server actions and other cases where you need all input types at once.
+ * @see https://vovk.dev/inference
+ * @example
+ * ```ts
+ * type Input = VovkInput<typeof MyController.myMethod>;
+ * // { params: { id: string }; query: { search: string }; body: { name: string } }
+ * ```
+ */
+export type VovkInput<T extends (...args: KnownAny[]) => unknown> = _OmitUndefinedOrUnknown<_VovkInputRaw<T>>;
+
 /**
  * Utility type to extract return type from both controller and client methods
  * @see https://vovk.dev/inference

--- a/test/src/client/CommonController.test.ts
+++ b/test/src/client/CommonController.test.ts
@@ -1,7 +1,7 @@
 import { CommonControllerRPC, CommonControllerDifferentFetcherRPC } from 'vovk-client';
 import { CommonControllerRPC as SegmentClientCommonControllerRPC } from '../../other-compiled-test-sources/segmented-client/foo/client/index.ts';
 import { CommonControllerRPC as BundleClientCommonControllerRPC } from '../../other-compiled-test-sources/bundle/index.mjs';
-import { HttpStatus, type VovkBody, type VovkQuery, type VovkReturnType, type VovkParams } from 'vovk';
+import { HttpStatus, type VovkBody, type VovkQuery, type VovkReturnType, type VovkParams, type VovkInput } from 'vovk';
 import type { VovkHandlerSchema, VovkErrorResponse } from 'vovk/internal';
 import { it, describe } from 'node:test';
 import { deepStrictEqual, ok, strictEqual } from 'node:assert';
@@ -212,6 +212,19 @@ describe('Client with vovk-client', () => {
     // @ts-expect-error Expect error
     null as unknown as VovkParams<typeof CommonController.getWithParams> satisfies { hello: 'foo' };
 
+    // VovkInput should only contain params (no body or query)
+    null as unknown as VovkInput<typeof CommonControllerRPC.getWithParams> satisfies { params: { hello: 'world' } };
+    // @ts-expect-error body should not exist on VovkInput when not defined
+    null as unknown as VovkInput<typeof CommonControllerRPC.getWithParams> satisfies { body: unknown };
+    // @ts-expect-error query should not exist on VovkInput when not defined
+    null as unknown as VovkInput<typeof CommonControllerRPC.getWithParams> satisfies { query: unknown };
+
+    null as unknown as VovkInput<typeof CommonController.getWithParams> satisfies { params: { hello: 'world' } };
+    // @ts-expect-error body should not exist on VovkInput when not defined
+    null as unknown as VovkInput<typeof CommonController.getWithParams> satisfies { body: unknown };
+    // @ts-expect-error query should not exist on VovkInput when not defined
+    null as unknown as VovkInput<typeof CommonController.getWithParams> satisfies { query: unknown };
+
     deepStrictEqual(result satisfies { hello: 'world' }, { hello: 'world' });
   });
 
@@ -230,6 +243,13 @@ describe('Client with vovk-client', () => {
 
     // @ts-expect-error Expect error
     null as unknown as VovkBody<typeof CommonControllerRPC.postWithAll> satisfies { hello: 'baz' };
+
+    // VovkInput should contain all three when all are defined
+    null as unknown as VovkInput<typeof CommonControllerRPC.postWithAll> satisfies {
+      params: { hello: 'world' };
+      body: { isBody: true };
+      query: { simpleQueryParam: 'queryValue' };
+    };
 
     deepStrictEqual(result satisfies VovkReturnType<typeof CommonControllerRPC.postWithAll>, {
       params: { hello: 'world' },

--- a/test/src/validation/WithValidationController.test.ts
+++ b/test/src/validation/WithValidationController.test.ts
@@ -9,6 +9,7 @@ import {
   type VovkOutput,
   type VovkIteration,
   type VovkBody,
+  type VovkInput,
 } from 'vovk';
 import type WithValidationController from './WithValidationController.ts';
 import { expectPromise, getConstrainingObject, NESTED_QUERY_EXAMPLE } from '../lib.ts';
@@ -100,6 +101,18 @@ describe('Validation with with zod and validateOnClient defined at settings', ()
     // @ts-expect-error Expect error
     null as unknown as VovkOutput<typeof WithValidationController.handleAll> satisfies null;
 
+    // VovkInput should contain all three when all are defined
+    null as unknown as VovkInput<typeof WithValidationRPC.handleAll> satisfies {
+      body: { hello: string };
+      query: { search: string };
+      params: { foo: string; bar: string };
+    };
+    null as unknown as VovkInput<typeof WithValidationController.handleAll> satisfies {
+      body: { hello: string };
+      query: { search: string };
+      params: { foo: string; bar: string };
+    };
+
     deepStrictEqual(result satisfies typeof expected, expected);
   });
 
@@ -111,6 +124,14 @@ describe('Validation with with zod and validateOnClient defined at settings', ()
       body: { no: 'body' },
     });
     deepStrictEqual(result satisfies { nothing: 'here' }, { nothing: 'here' });
+
+    // VovkInput should be empty when no inputs are defined
+    // @ts-expect-error body should not exist on VovkInput when not defined
+    null as unknown as VovkInput<typeof WithValidationRPC.handleNothitng> satisfies { body: unknown };
+    // @ts-expect-error query should not exist on VovkInput when not defined
+    null as unknown as VovkInput<typeof WithValidationRPC.handleNothitng> satisfies { query: unknown };
+    // @ts-expect-error params should not exist on VovkInput when not defined
+    null as unknown as VovkInput<typeof WithValidationRPC.handleNothitng> satisfies { params: unknown };
   });
 
   it('Should handle body validation and client', async () => {
@@ -142,6 +163,13 @@ describe('Validation with with zod and validateOnClient defined at settings', ()
 
     await rejects.toThrow(/Client-side validation failed. Invalid body: data\/hello.*/);
     await rejects.toThrowError(HttpException);
+
+    // VovkInput should only contain body (no query or params)
+    null as unknown as VovkInput<typeof WithValidationRPC.handleBody> satisfies { body: { hello: string } };
+    // @ts-expect-error query should not exist on VovkInput when not defined
+    null as unknown as VovkInput<typeof WithValidationRPC.handleBody> satisfies { query: unknown };
+    // @ts-expect-error params should not exist on VovkInput when not defined
+    null as unknown as VovkInput<typeof WithValidationRPC.handleBody> satisfies { params: unknown };
   });
 
   it('Should handle params validation and client', async () => {
@@ -175,6 +203,15 @@ describe('Validation with with zod and validateOnClient defined at settings', ()
 
     await rejects.toThrow(/Client-side validation failed. Invalid params: data\/foo.*/);
     await rejects.toThrowError(HttpException);
+
+    // VovkInput should only contain params (no body or query)
+    null as unknown as VovkInput<typeof WithValidationRPC.handleParams> satisfies {
+      params: { foo: string; bar: string };
+    };
+    // @ts-expect-error body should not exist on VovkInput when not defined
+    null as unknown as VovkInput<typeof WithValidationRPC.handleParams> satisfies { body: unknown };
+    // @ts-expect-error query should not exist on VovkInput when not defined
+    null as unknown as VovkInput<typeof WithValidationRPC.handleParams> satisfies { query: unknown };
   });
 
   it('Should handle query validation and client', async () => {
@@ -206,6 +243,13 @@ describe('Validation with with zod and validateOnClient defined at settings', ()
 
     await rejects.toThrow(/Client-side validation failed. Invalid query: data\/search.*/);
     await rejects.toThrowError(HttpException);
+
+    // VovkInput should only contain query (no body or params)
+    null as unknown as VovkInput<typeof WithValidationRPC.handleQuery> satisfies { query: { search: string } };
+    // @ts-expect-error body should not exist on VovkInput when not defined
+    null as unknown as VovkInput<typeof WithValidationRPC.handleQuery> satisfies { body: unknown };
+    // @ts-expect-error params should not exist on VovkInput when not defined
+    null as unknown as VovkInput<typeof WithValidationRPC.handleQuery> satisfies { params: unknown };
   });
 
   it('Should handle nested queries and client', async () => {


### PR DESCRIPTION
Add `VovkInput<T>` combines body, query, params:

```ts
type VovkInput<T> = {
  params: VovkParams<T>;
  query: VovkQuery<T>;
  body: VovkBody<T>;
};
```