### PR TITLE
fix(main): LPCs (.fn calls) fixes

### DIFF
--- a/packages/vovk-cli/src/init/updateTypeScriptConfig.mts
+++ b/packages/vovk-cli/src/init/updateTypeScriptConfig.mts
@@ -3,10 +3,7 @@ import fs from 'node:fs/promises';
 import * as jsonc from 'jsonc-parser';
 import { prettify } from '../utils/prettify.mjs';
 
-export async function updateTypeScriptConfig(
-  root: string,
-  compilerOptions: { experimentalDecorators?: true; }
-) {
+export async function updateTypeScriptConfig(root: string, compilerOptions: { experimentalDecorators?: true }) {
   const tsconfigPath = path.join(root, 'tsconfig.json');
   const tsconfigContent = await fs.readFile(tsconfigPath, 'utf8');
 

--- a/packages/vovk/src/validation/createStandardValidation.ts
+++ b/packages/vovk/src/validation/createStandardValidation.ts
@@ -3,7 +3,7 @@ import { HttpException } from '../core/HttpException.js';
 import { createToolFactory } from '../tools/createToolFactory.js';
 import { HttpStatus } from './createValidateOnClient.js';
 import type { VovkRequest } from '../types/request.js';
-import type { CombinedSpec, ContentType, NormalizeContentType } from '../types/validation.js';
+import type { BodyTypeFromContentType, CombinedSpec, ContentType, NormalizeContentType } from '../types/validation.js';
 import type { VovkValidationType } from '../types/core.js';
 import type { VovkOperationObject } from '../types/operation.js';
 import type { KnownAny } from '../types/utils.js';
@@ -119,7 +119,9 @@ export function createStandardValidation({
     isRPC?: boolean;
     fn: {
       <TTransformed>(input: {
-        body?: TBody extends CombinedSpec ? CombinedSpec.InferOutput<TBody> : undefined;
+        body?: TBody extends CombinedSpec
+          ? BodyTypeFromContentType<NormalizeContentType<TContentType>, CombinedSpec.InferOutput<TBody>>
+          : undefined;
         query?: TQuery extends CombinedSpec ? CombinedSpec.InferOutput<TQuery> : undefined;
         params?: TParams extends CombinedSpec ? CombinedSpec.InferOutput<TParams> : undefined;
         meta?: Record<string, KnownAny>;
@@ -127,14 +129,18 @@ export function createStandardValidation({
         transform: (data: Awaited<ReturnType<THandleFn>>, fakeReq: Pick<TReq, 'vovk'>) => TTransformed;
       }): Promise<TTransformed>;
       <TReturnType = ReturnType<THandleFn>>(input?: {
-        body?: TBody extends CombinedSpec ? CombinedSpec.InferOutput<TBody> : undefined;
+        body?: TBody extends CombinedSpec
+          ? BodyTypeFromContentType<NormalizeContentType<TContentType>, CombinedSpec.InferOutput<TBody>>
+          : undefined;
         query?: TQuery extends CombinedSpec ? CombinedSpec.InferOutput<TQuery> : undefined;
         params?: TParams extends CombinedSpec ? CombinedSpec.InferOutput<TParams> : undefined;
         meta?: Record<string, KnownAny>;
         disableClientValidation?: boolean;
       }): TReturnType;
       (input?: {
-        body?: TBody extends CombinedSpec ? CombinedSpec.InferOutput<TBody> : undefined;
+        body?: TBody extends CombinedSpec
+          ? BodyTypeFromContentType<NormalizeContentType<TContentType>, CombinedSpec.InferOutput<TBody>>
+          : undefined;
         query?: TQuery extends CombinedSpec ? CombinedSpec.InferOutput<TQuery> : undefined;
         params?: TParams extends CombinedSpec ? CombinedSpec.InferOutput<TParams> : undefined;
         meta?: Record<string, KnownAny>;

--- a/packages/vovk/src/validation/withValidationLibrary.ts
+++ b/packages/vovk/src/validation/withValidationLibrary.ts
@@ -5,11 +5,12 @@ import { JSONLinesResponder } from '../core/JSONLinesResponder.js';
 import { HttpStatus } from '../types/enums.js';
 import type { VovkHandlerSchema, VovkValidationType } from '../types/core.js';
 import type { VovkRequest } from '../types/request.js';
-import type { ContentType, VovkTypedProcedure } from '../types/validation.js';
+import type { BodyTypeFromContentType, ContentType, VovkTypedProcedure } from '../types/validation.js';
 import type { VovkOperationObject } from '../types/operation.js';
 import type { KnownAny } from '../types/utils.js';
 import { validateContentType } from '../req/validateContentType.js';
 import { bufferBody } from '../req/bufferBody.js';
+import { parseForm } from '../req/parseForm.js';
 
 const validationTypes: VovkValidationType[] = ['body', 'query', 'params', 'output', 'iteration'] as const;
 
@@ -187,10 +188,12 @@ export function withValidationLibrary<
     wrapper?: (req: VovkRequestAny, params: Parameters<THandle>[1]) => ReturnType<THandle>;
   };
 
+  type FnBody = BodyTypeFromContentType<TContentType, THandle['__types']['body']>;
+
   type FnInput = {
     disableClientValidation?: boolean;
     transform?: undefined;
-  } & (undefined extends typeof body ? { body?: THandle['__types']['body'] } : { body: THandle['__types']['body'] }) &
+  } & (undefined extends typeof body ? { body?: FnBody } : { body: FnBody }) &
     (undefined extends typeof query
       ? { query?: THandle['__types']['query'] }
       : { query: THandle['__types']['query'] }) &
@@ -220,14 +223,24 @@ export function withValidationLibrary<
   function fn<TReturnType = ReturnType<THandle>, TTransformed = never>(
     input?: FnInput | FnInputWithTransform<TTransformed>
   ): TReturnType | Promise<TTransformed> {
+    let bodyCache: unknown;
+
     const fakeReq: Pick<
       VovkRequest<THandle['__types']['body'], THandle['__types']['query'], THandle['__types']['params']>,
       'vovk'
     > = {
       vovk: {
-        body: () => Promise.resolve((input?.body ?? {}) as THandle['__types']['body']),
-        query: () => (input?.query ?? {}) as THandle['__types']['query'],
-        params: () => (input?.params ?? {}) as THandle['__types']['params'],
+        body: () => {
+          if (input && input.body instanceof FormData) {
+            bodyCache ??= parseForm(input.body);
+          } else {
+            bodyCache = input?.body;
+          }
+
+          return Promise.resolve(bodyCache ?? null);
+        },
+        query: () => input?.query ?? {},
+        params: () => input?.params ?? {},
         meta: <T = KnownAny>(meta?: T | null) => reqMeta<T>(fakeReq, meta),
       },
     };

--- a/test/src/common/procedure.test.ts
+++ b/test/src/common/procedure.test.ts
@@ -134,6 +134,22 @@ describe('procedure features', async () => {
     result satisfies { message: string };
   });
 
+  it('Should convert FormData to an object when passed as a body', async () => {
+    const formData = new FormData();
+    formData.append('foo', 'bar');
+
+    const handler = procedure({
+      contentType: ['multipart/form-data'],
+      body: z.object({
+        foo: z.literal('bar'),
+      }),
+    }).handle(({ vovk }) => {
+      return vovk.body();
+    });
+
+    assert.deepEqual(await handler.fn({ body: formData }), { foo: 'bar' });
+  });
+
   it('Should assign schema', async () => {
     assert.equal(handler.schema.validation?.body?.$schema, 'https://json-schema.org/draft/2020-12/schema');
     assert.equal(handler.schema.validation?.query?.$schema, 'https://json-schema.org/draft/2020-12/schema');


### PR DESCRIPTION
- LPCs (`.fn` calls) change call signature based on `contentType`
- `.fn` calls will parse formData by default to enable LPC calls inside Next.js actions

```ts
class UserController {
  static createUser = procedure({
    contentType: ['multipart/form-data'],
    body: z.object({
      name: z.string(),
    }),
  }).handle(({ vovk }) => {
    return vovk.body(); // { name: 'John' }
  });
}
```

```ts
export default function CreateUserPage() {
  async function handleCreate(body: FormData) {
    'use server';
    await UserController.createUser.fn({ body });
  }

  return (
    <form action={handleCreate}>
      <input name="name" required />
      <button type="submit">Create User</button>
    </form>
  );
}
```