### PR TITLE
feat(main): Allow to set `onSuccess` and `onError` callbacks as events after fetcher initialization

### DIFF
--- a/packages/vovk/src/client/fetcher.ts
+++ b/packages/vovk/src/client/fetcher.ts
@@ -7,6 +7,23 @@ export const DEFAULT_ERROR_MESSAGE = 'Unknown error at default fetcher';
 
 export type { VovkFetcher };
 
+export type CreateFetcherOnSuccess<T> = (
+  respData: unknown,
+  options: VovkFetcherOptions<T>,
+  info: { response: Response; init: RequestInit; schema: VovkHandlerSchema }
+) => void | Promise<void>;
+
+export type CreateFetcherOnError<T> = (
+  error: HttpException,
+  options: VovkFetcherOptions<T>,
+  info: {
+    response: Response | null;
+    init: RequestInit | null;
+    respData: unknown | null;
+    schema: VovkHandlerSchema;
+  }
+) => void | Promise<void>;
+
 /**
  * Creates a customizable fetcher function for client requests.
  * @see https://vovk.dev/imports
@@ -14,8 +31,8 @@ export type { VovkFetcher };
 export function createFetcher<T>({
   prepareRequestInit,
   transformResponse,
-  onSuccess,
-  onError,
+  onSuccess: onSuccessInit,
+  onError: onErrorInit,
 }: {
   prepareRequestInit?: (init: RequestInit, options: VovkFetcherOptions<T>) => RequestInit | Promise<RequestInit>;
   transformResponse?: (
@@ -23,22 +40,11 @@ export function createFetcher<T>({
     options: VovkFetcherOptions<T>,
     info: { response: Response; init: RequestInit; schema: VovkHandlerSchema }
   ) => unknown | Promise<unknown>;
-  onSuccess?: (
-    respData: unknown,
-    options: VovkFetcherOptions<T>,
-    info: { response: Response; init: RequestInit; schema: VovkHandlerSchema }
-  ) => void | Promise<void>;
-  onError?: (
-    error: HttpException,
-    options: VovkFetcherOptions<T>,
-    info: {
-      response: Response | null;
-      init: RequestInit | null;
-      respData: unknown | null;
-      schema: VovkHandlerSchema;
-    }
-  ) => void | Promise<void>;
+  onSuccess?: CreateFetcherOnSuccess<T>;
+  onError?: CreateFetcherOnError<T>;
 } = {}) {
+  const onSuccessCallbacks: CreateFetcherOnSuccess<T>[] = onSuccessInit ? [onSuccessInit] : [];
+  const onErrorCallbacks: CreateFetcherOnError<T>[] = onErrorInit ? [onErrorInit] : [];
   // fetcher uses HttpException class to throw errors of fake HTTP status 0 if client-side error occurs
   // For normal HTTP errors, it uses message and status code from the response of VovkErrorResponse type
   const newFetcher: VovkFetcher<VovkFetcherOptions<T>> = async (
@@ -157,17 +163,28 @@ export function createFetcher<T>({
         ? await transformResponse(respData, inputOptions, { response, init: requestInit, schema })
         : respData;
 
-      await onSuccess?.(respData, inputOptions, { response, init: requestInit, schema });
+      for (const cb of onSuccessCallbacks) {
+        await cb(respData, inputOptions, { response, init: requestInit, schema });
+      }
 
       return [respData, response];
     } catch (error) {
-      await onError?.(error as HttpException, inputOptions, { response, init: requestInit, respData, schema });
+      for (const cb of onErrorCallbacks) {
+        await cb(error as HttpException, inputOptions, { response, init: requestInit, respData, schema });
+      }
 
       throw error;
     }
   };
 
-  return newFetcher;
+  return Object.assign(newFetcher, {
+    onSuccess(cb: CreateFetcherOnSuccess<T>) {
+      onSuccessCallbacks.push(cb);
+    },
+    onError(cb: CreateFetcherOnError<T>) {
+      onErrorCallbacks.push(cb);
+    },
+  });
 }
 
 /**

--- a/test/src/client/CommonController.test.ts
+++ b/test/src/client/CommonController.test.ts
@@ -7,6 +7,7 @@ import { it, describe } from 'node:test';
 import { deepStrictEqual, ok, strictEqual } from 'node:assert';
 import type CommonController from './CommonController.ts';
 import { NESTED_QUERY_EXAMPLE } from '../lib.ts';
+import { fetcher } from '../lib/fetcher.ts';
 import omit from 'lodash/omit.js';
 import noop from 'lodash/noop.js';
 
@@ -353,5 +354,54 @@ describe('Client with vovk-client', () => {
   it('Should extract URL using getURL method without parameters and without apiRoot parameter', async () => {
     const url = CommonControllerRPC.getHelloWorldObjectLiteral.getURL();
     deepStrictEqual(url, `${apiRoot}/foo/client/common/get-hello-world-object-literal`);
+  });
+
+  it(`Should call multiple onSuccess and onError callbacks registered via fetcher.onSuccess/onError methods`, async () => {
+    const onSuccessCalls: { source: string; successMessage?: string }[] = [];
+    const onErrorCalls: { source: string; message: string; successMessage?: string }[] = [];
+
+    fetcher.onSuccess((_respData, { successMessage }) => {
+      onSuccessCalls.push({ source: 'callback1', successMessage });
+    });
+
+    fetcher.onSuccess((_respData, { successMessage }) => {
+      onSuccessCalls.push({ source: 'callback2', successMessage });
+    });
+
+    fetcher.onError((error, { successMessage }) => {
+      onErrorCalls.push({ source: 'callback1', message: error.message, successMessage });
+    });
+
+    fetcher.onError((error, { successMessage }) => {
+      onErrorCalls.push({ source: 'callback2', message: error.message, successMessage });
+    });
+
+    await CommonControllerDifferentFetcherRPC.getHelloWorldHeaders({
+      apiRoot,
+      init: { headers: { 'x-vovk-test': 'world' } },
+      successMessage: 'SuccessTest',
+    });
+
+    deepStrictEqual(
+      onSuccessCalls.map((c) => c.source),
+      ['callback1', 'callback2']
+    );
+    ok(onSuccessCalls.every((c) => c.successMessage === 'SuccessTest'));
+
+    try {
+      await CommonControllerDifferentFetcherRPC.getErrorResponse({
+        apiRoot,
+        successMessage: 'ErrorTest',
+      });
+    } catch {
+      // expected
+    }
+
+    deepStrictEqual(
+      onErrorCalls.map((c) => c.source),
+      ['callback1', 'callback2']
+    );
+    ok(onErrorCalls.every((c) => c.message === 'This is an error'));
+    ok(onErrorCalls.every((c) => c.successMessage === 'ErrorTest'));
   });
 });


### PR DESCRIPTION
Allow to set `onSuccess` and `onError` callbacks as events after fetcher initialization. 

```ts                                                                                                                                                                                                                                                                            
import { createFetcher } from 'vovk';

// Current: onSuccess and onError set when fetcher is initialized
export const fetcher = createFetcher<{ bypassRegistry?: boolean }>({                                                                                                                                                                                                         
  transformResponse: async (data, { bypassRegistry }) => {                                                                                                                                                                                                                   
    // ...                                                                                                                                                                                                                                                                   
  },                                                                                                                                                                                                                                                                         
  onError: (error, { bypassRegistry }) => {                                                                                                                                                                                                                                  
    // ...                                                                                                                                                                                                                                                                   
  },                                                                                                                                                                                                                                                                         
  onSuccess: (respData, { bypassRegistry }) => {}                                                                                                                                                                                                                            
});                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                             
// New: onSuccess and onError callbacks can also be assigned later
fetcher.onError((error, { bypassRegistry }) => {                                                                                                                                                                                                                             
  // ...                                                                                                                                                                                                                                                                     
})                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                             
fetcher.onSuccess((respData, { bypassRegistry }) => {                                                                                                                                                                                                                        
  // ...                                                                                                                                                                                                                                                                     
})                                                                                                                                                                                                                                                                           
```

**Why?**
Useful when `onSuccess` needs to handle context provider value.