### PR TITLE
Pin CI runner images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-24.04, macos-14]
         node-version: [22, 23, 24, 25]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Summary
- Pin `runs-on` to `ubuntu-24.04` and `macos-14` instead of the `-latest` labels so weekly GitHub runner-image sub-version bumps don't silently change test behavior between runs.

## Context
Two CI runs for the same commit (`46a20495`) produced different results six days apart:
- 2026-04-16: image `20260406.80.1` → passed
- 2026-04-22: image `20260413.86.1` → failed (`UnhandledPromiseRejection: "[object Array]"` during dev-server shutdown)

Deltas between images were minor patch bumps (Python 3.13.12 → 3.13.13, OpenSSL, systemd) but enough to shift timing and expose flakiness.

## Test plan
- [ ] CI green on the PR
- [ ] If CI still fails, drift wasn't the root cause — follow up on the `[object Array]` rejection in the Next.js dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)