### PR TITLE
Fix CI: use macos-latest after macos-14 broke node-pty on Node 25

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-24.04, macos-14]
+        os: [ubuntu-24.04, macos-latest]
         node-version: [22, 23, 24, 25]
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
## Summary
Fix for the regression introduced by #4. `macos-latest` was resolving to `macos-15-arm64` at the time of the last green run, but #4 pinned to `macos-14`, which broke `node-pty` native compilation on Node 25 (incompatible V8 headers → `expected expression` in v8-object.h / v8-context.h).

Restore macOS to the rolling `macos-latest` label since drift on that axis is acceptable. Ubuntu stays pinned to `ubuntu-24.04`.

## Test plan
- [ ] CI green on all 8 matrix jobs