### PR TITLE
docs(claude-plugin): multi-agent install table

### DIFF
--- a/packages/claude-plugin/README.md
+++ b/packages/claude-plugin/README.md
@@ -37,23 +37,21 @@ The plugin packages all of this as 14 topic-scoped skills the agent loads only w
 
 ## Install
 
-Inside Claude Code:
+Pick your agent. One command. Done.
 
-```
-/plugin marketplace add finom/vovk
-/plugin install vovk@vovk
-/reload-plugins
-```
+| Agent | Install |
+|-------|---------|
+| **Claude Code** (CLI) | `claude plugin marketplace add finom/vovk && claude plugin install vovk@vovk` |
+| **Claude Code** (interactive) | Inside the session: `/plugin marketplace add finom/vovk` then `/plugin install vovk@vovk` |
+| **Cursor** | `npx skills add finom/vovk -a cursor` |
+| **Windsurf** | `npx skills add finom/vovk -a windsurf` |
+| **Copilot** | `npx skills add finom/vovk -a github-copilot` |
+| **Cline** | `npx skills add finom/vovk -a cline` |
+| **Any other** | `npx skills add finom/vovk` |
 
-The `finom/vovk` shorthand resolves to the GitHub repo's `.claude-plugin/marketplace.json`. For private forks, ensure your `gh` auth is set; for a local checkout, replace the first command with `/plugin marketplace add /path/to/vovk` (point at the repo root, not at `packages/claude-plugin/`).
+`finom/vovk` resolves to the GitHub repo's `.claude-plugin/marketplace.json`. The plugin name is `vovk`; the marketplace name is also `vovk` — `vovk@vovk` is `<plugin-name>@<marketplace-name>`. For a local checkout, substitute a path: `claude plugin marketplace add /path/to/vovk` (point at the repo root, not at `packages/claude-plugin/`).
 
-Verify it loaded:
-
-```
-/plugin
-```
-
-The **Installed** tab should list `vovk`. Skills are namespaced — running `/vovk:` (with the trailing colon) lists all 14 skills available to the agent.
+In Claude Code, verify with `/plugin` — the **Installed** tab should list `vovk`. Skills are namespaced; `/vovk:` lists all 14.
 
 ## First prompt to try
 


### PR DESCRIPTION
## Summary

Replaces the \`Inside Claude Code: /plugin marketplace add ...\` recipe with a multi-agent install table:

- **Claude Code (CLI)** — \`claude plugin marketplace add finom/vovk && claude plugin install vovk@vovk\` (works in any terminal, including non-interactive contexts where slash commands are unavailable)
- **Claude Code (interactive)** — slash-command variant, kept for users already inside a session
- **Cursor / Windsurf / Copilot / Cline / generic** — \`npx skills add finom/vovk -a <agent>\` rows mirroring the layout used by [JuliusBrussee/caveman](https://github.com/JuliusBrussee/caveman)

The \`/plugin\` slash command turned out not to be available in every Claude Code GUI integration, so a CLI-first install path is more universally reachable.

Verified the CLI form end-to-end:
- \`claude plugin marketplace add finom/vovk\` — resolves \`finom/vovk\` shorthand, clones, validates, registers marketplace
- \`claude plugin install vovk@vovk\` — installs the plugin (vovk@vovk, version 0.1.0, scope: user, status: enabled)
- \`claude plugin list\` — confirms install

## Test plan

- [ ] Render README on GitHub and confirm the table renders correctly.
- [ ] Spot-check that the CLI form is the first / primary row.