### PR TITLE
feat(vovk): add validationSchemasObjectToSingleValidationSchema

### DIFF
--- a/packages/vovk/src/internal.ts
+++ b/packages/vovk/src/internal.ts
@@ -3,6 +3,7 @@ export { deepExtend } from './utils/deepExtend.js';
 export { resolveGeneratorConfigValues } from './core/resolveGeneratorConfigValues.js';
 export { createCodeSamples } from './samples/createCodeSamples.js';
 export { withValidationLibrary } from './validation/withValidationLibrary.js';
+export { validationSchemasObjectToSingleValidationSchema } from './validation/validationSchemasObjectToSingleValidationSchema.js';
 export { operation } from './openapi/operation.js';
 export { openAPIToVovkSchema } from './openapi/openAPIToVovkSchema/index.js';
 export { vovkSchemaToOpenAPI } from './openapi/vovkSchemaToOpenAPI.js';

--- a/packages/vovk/src/validation/validationSchemasObjectToSingleValidationSchema.ts
+++ b/packages/vovk/src/validation/validationSchemasObjectToSingleValidationSchema.ts
@@ -1,0 +1,133 @@
+import type { CombinedProps, CombinedSpec } from '../types/validation.js';
+import type { StandardJSONSchemaV1, StandardSchemaV1 } from '../types/standard-schema.js';
+
+const SLOT_KEYS = ['body', 'query', 'params'] as const;
+type SlotKey = (typeof SLOT_KEYS)[number];
+
+type SchemasObject = {
+  body?: CombinedSpec;
+  query?: CombinedSpec;
+  params?: CombinedSpec;
+};
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === 'object' && value !== null && typeof (value as { then?: unknown }).then === 'function'
+  );
+}
+
+function prefixIssues(
+  issues: ReadonlyArray<StandardSchemaV1.Issue>,
+  slot: SlotKey
+): StandardSchemaV1.Issue[] {
+  return issues.map((issue) => ({
+    message: issue.message,
+    path: [{ key: slot }, ...(issue.path ?? [])],
+  }));
+}
+
+/**
+ * Combine optional `body` / `query` / `params` Standard Schemas into a single
+ * `CombinedSpec` whose `~standard` interface fully conforms to Standard Schema
+ * + Standard JSON Schema. Top-level validation (object shape, key presence,
+ * rejection of unknown keys) is handled here; per-slot value validation and
+ * JSON Schema conversion are delegated to the slot schemas.
+ *
+ * Internal helper. Not exported from the public `vovk` entrypoint.
+ */
+export function validationSchemasObjectToSingleValidationSchema<TSchemas extends SchemasObject>(
+  schemas: TSchemas
+): CombinedSpec & TSchemas {
+  const definedSlots = SLOT_KEYS.filter((key) => schemas[key] !== undefined);
+  const definedSlotSet = new Set<string>(definedSlots);
+
+  const validate = (
+    input: unknown
+  ): StandardSchemaV1.Result<unknown> | Promise<StandardSchemaV1.Result<unknown>> => {
+    if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+      return { issues: [{ message: 'Expected object', path: [] }] };
+    }
+
+    const topLevelIssues: StandardSchemaV1.Issue[] = [];
+    const inputRecord = input as Record<string, unknown>;
+
+    for (const slot of definedSlots) {
+      if (!(slot in inputRecord)) {
+        topLevelIssues.push({ message: 'Required', path: [{ key: slot }] });
+      }
+    }
+
+    for (const key of Object.keys(inputRecord)) {
+      if (!definedSlotSet.has(key)) {
+        topLevelIssues.push({ message: 'Unexpected key', path: [{ key }] });
+      }
+    }
+
+    type SlotPending = {
+      slot: SlotKey;
+      result: StandardSchemaV1.Result<unknown> | Promise<StandardSchemaV1.Result<unknown>>;
+    };
+    const pending: SlotPending[] = [];
+    for (const slot of definedSlots) {
+      if (slot in inputRecord) {
+        pending.push({ slot, result: schemas[slot]!['~standard'].validate(inputRecord[slot]) });
+      }
+    }
+
+    const combine = (
+      resolved: { slot: SlotKey; result: StandardSchemaV1.Result<unknown> }[]
+    ): StandardSchemaV1.Result<unknown> => {
+      const issues: StandardSchemaV1.Issue[] = [...topLevelIssues];
+      const value: Record<string, unknown> = {};
+      for (const { slot, result } of resolved) {
+        if (result.issues?.length) {
+          issues.push(...prefixIssues(result.issues, slot));
+        } else {
+          value[slot] = (result as StandardSchemaV1.SuccessResult<unknown>).value;
+        }
+      }
+      return issues.length > 0 ? { issues } : { value };
+    };
+
+    if (pending.some(({ result }) => isThenable(result))) {
+      return Promise.all(
+        pending.map(async ({ slot, result }) => ({ slot, result: await result }))
+      ).then(combine);
+    }
+
+    return combine(pending as { slot: SlotKey; result: StandardSchemaV1.Result<unknown> }[]);
+  };
+
+  const buildJSONSchema = (
+    options: StandardJSONSchemaV1.Options,
+    direction: 'input' | 'output'
+  ): Record<string, unknown> => {
+    const properties: Record<string, Record<string, unknown>> = {};
+    for (const slot of definedSlots) {
+      properties[slot] = schemas[slot]!['~standard'].jsonSchema?.[direction](options) ?? {};
+    }
+    return {
+      type: 'object',
+      properties,
+      required: [...definedSlots],
+      additionalProperties: false,
+    };
+  };
+
+  const standard: CombinedProps = {
+    version: 1,
+    vendor: 'vovk',
+    validate,
+    jsonSchema: {
+      input: (options) => buildJSONSchema(options, 'input'),
+      output: (options) => buildJSONSchema(options, 'output'),
+    },
+  };
+
+  const result: SchemasObject & { '~standard': CombinedProps } = { '~standard': standard };
+  if (schemas.body !== undefined) result.body = schemas.body;
+  if (schemas.query !== undefined) result.query = schemas.query;
+  if (schemas.params !== undefined) result.params = schemas.params;
+
+  return result as CombinedSpec & TSchemas;
+}

--- a/test/src/common/validationSchemasObjectToSingleValidationSchema.test.ts
+++ b/test/src/common/validationSchemasObjectToSingleValidationSchema.test.ts
@@ -1,0 +1,292 @@
+import { it, describe } from 'node:test';
+import assert from 'node:assert';
+import { z } from 'zod';
+import { validationSchemasObjectToSingleValidationSchema } from 'vovk/internal';
+
+type StandardResult = { value?: unknown; issues?: ReadonlyArray<{ message: string; path?: unknown[] }> };
+
+function makeMockSchema(opts: {
+  validate?: (input: unknown) => StandardResult | Promise<StandardResult>;
+  input?: (target: string) => Record<string, unknown>;
+  output?: (target: string) => Record<string, unknown>;
+}) {
+  return {
+    '~standard': {
+      version: 1 as const,
+      vendor: 'mock',
+      validate: opts.validate ?? ((input: unknown) => ({ value: input })),
+      jsonSchema: {
+        input: ({ target }: { target: string }) =>
+          opts.input ? opts.input(target) : { type: 'object', marker: 'input', target },
+        output: ({ target }: { target: string }) =>
+          opts.output ? opts.output(target) : { type: 'object', marker: 'output', target },
+      },
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test fixture conforming to CombinedSpec
+  } as any;
+}
+
+describe('validationSchemasObjectToSingleValidationSchema', () => {
+  describe('Standard Schema spec compliance', () => {
+    it('exposes version=1 and vendor=vovk on ~standard', () => {
+      const merged = validationSchemasObjectToSingleValidationSchema({});
+      assert.strictEqual(merged['~standard'].version, 1);
+      assert.strictEqual(merged['~standard'].vendor, 'vovk');
+      assert.strictEqual(typeof merged['~standard'].validate, 'function');
+      assert.strictEqual(typeof merged['~standard'].jsonSchema.input, 'function');
+      assert.strictEqual(typeof merged['~standard'].jsonSchema.output, 'function');
+    });
+
+    it('exposes pass-through slot references on the result object', () => {
+      const bodySchema = z.object({ foo: z.string() });
+      const querySchema = z.object({ bar: z.number() });
+      const merged = validationSchemasObjectToSingleValidationSchema({
+        body: bodySchema,
+        query: querySchema,
+      });
+      assert.strictEqual(merged.body, bodySchema);
+      assert.strictEqual(merged.query, querySchema);
+      assert.strictEqual(merged.params, undefined);
+    });
+  });
+
+  describe('validate — top-level shape', () => {
+    const merged = validationSchemasObjectToSingleValidationSchema({
+      body: z.object({ foo: z.string() }),
+    });
+
+    it('rejects null with empty path', () => {
+      const result = merged['~standard'].validate(null) as StandardResult;
+      assert.ok(result.issues);
+      assert.deepStrictEqual(result.issues[0], { message: 'Expected object', path: [] });
+    });
+
+    it('rejects array', () => {
+      const result = merged['~standard'].validate([]) as StandardResult;
+      assert.ok(result.issues);
+      assert.deepStrictEqual(result.issues[0], { message: 'Expected object', path: [] });
+    });
+
+    it('rejects primitive (string)', () => {
+      const result = merged['~standard'].validate('hello') as StandardResult;
+      assert.ok(result.issues);
+      assert.deepStrictEqual(result.issues[0], { message: 'Expected object', path: [] });
+    });
+
+    it('rejects primitive (number)', () => {
+      const result = merged['~standard'].validate(42) as StandardResult;
+      assert.ok(result.issues);
+      assert.deepStrictEqual(result.issues[0], { message: 'Expected object', path: [] });
+    });
+
+    it('accepts empty object when no slots defined', () => {
+      const empty = validationSchemasObjectToSingleValidationSchema({});
+      const result = empty['~standard'].validate({}) as StandardResult;
+      assert.strictEqual(result.issues, undefined);
+      assert.deepStrictEqual(result.value, {});
+    });
+  });
+
+  describe('validate — key presence and strict rejection', () => {
+    it('reports missing defined slot with prefixed path', () => {
+      const merged = validationSchemasObjectToSingleValidationSchema({
+        body: z.object({ foo: z.string() }),
+      });
+      const result = merged['~standard'].validate({}) as StandardResult;
+      assert.ok(result.issues);
+      const missing = result.issues.find((i) => i.message === 'Required');
+      assert.deepStrictEqual(missing?.path, [{ key: 'body' }]);
+    });
+
+    it('reports unexpected key with prefixed path', () => {
+      const merged = validationSchemasObjectToSingleValidationSchema({
+        body: z.object({ foo: z.string() }),
+      });
+      const result = merged['~standard'].validate({
+        body: { foo: 'x' },
+        extra: 'oops',
+      }) as StandardResult;
+      assert.ok(result.issues);
+      const unexpected = result.issues.find((i) => i.message === 'Unexpected key');
+      assert.deepStrictEqual(unexpected?.path, [{ key: 'extra' }]);
+    });
+
+    it('aggregates multiple top-level problems (does not short-circuit)', () => {
+      const merged = validationSchemasObjectToSingleValidationSchema({
+        body: z.object({ foo: z.string() }),
+        query: z.object({ bar: z.number() }),
+      });
+      const result = merged['~standard'].validate({ extra1: 1, extra2: 2 }) as StandardResult;
+      assert.ok(result.issues);
+      const messages = result.issues.map((i) => {
+        const key = ((i.path?.[0] as { key?: string } | undefined)?.key as string) ?? '';
+        return `${i.message}:${key}`;
+      });
+      assert.ok(messages.includes('Required:body'));
+      assert.ok(messages.includes('Required:query'));
+      assert.ok(messages.includes('Unexpected key:extra1'));
+      assert.ok(messages.includes('Unexpected key:extra2'));
+    });
+  });
+
+  describe('validate — delegation to slot schemas', () => {
+    it('returns success with parsed values when all slots valid', () => {
+      const merged = validationSchemasObjectToSingleValidationSchema({
+        body: z.object({ foo: z.string() }),
+        query: z.object({ bar: z.number() }),
+        params: z.object({ baz: z.string() }),
+      });
+      const result = merged['~standard'].validate({
+        body: { foo: 'a' },
+        query: { bar: 1 },
+        params: { baz: 'b' },
+      }) as StandardResult;
+      assert.strictEqual(result.issues, undefined);
+      assert.deepStrictEqual(result.value, {
+        body: { foo: 'a' },
+        query: { bar: 1 },
+        params: { baz: 'b' },
+      });
+    });
+
+    it('prefixes slot validation issues with the slot key segment', () => {
+      const merged = validationSchemasObjectToSingleValidationSchema({
+        body: z.object({ foo: z.string() }),
+      });
+      const result = merged['~standard'].validate({ body: { foo: 42 } }) as StandardResult;
+      assert.ok(result.issues);
+      assert.ok(result.issues.length > 0);
+      const first = result.issues[0]!;
+      assert.deepStrictEqual(first.path?.[0], { key: 'body' });
+      assert.ok((first.path?.length ?? 0) >= 2, 'expected slot path to be prefixed onto slot’s own path');
+    });
+
+    it('keeps sync when all slot validators are sync', () => {
+      const merged = validationSchemasObjectToSingleValidationSchema({
+        body: z.object({ foo: z.string() }),
+      });
+      const result = merged['~standard'].validate({ body: { foo: 'x' } });
+      assert.strictEqual(
+        typeof (result as { then?: unknown }).then,
+        'undefined',
+        'sync slots should produce a sync Result'
+      );
+    });
+
+    it('returns a Promise when any slot validator is async', async () => {
+      const asyncSlot = makeMockSchema({
+        validate: async (input) => ({ value: input }),
+      });
+      const merged = validationSchemasObjectToSingleValidationSchema({
+        body: asyncSlot,
+      });
+      const result = merged['~standard'].validate({ body: { foo: 'x' } });
+      assert.strictEqual(typeof (result as { then?: unknown }).then, 'function');
+      const awaited = (await result) as StandardResult;
+      assert.deepStrictEqual(awaited.value, { body: { foo: 'x' } });
+    });
+
+    it('returns a Promise on mixed sync + async slots', async () => {
+      const merged = validationSchemasObjectToSingleValidationSchema({
+        body: z.object({ foo: z.string() }),
+        query: makeMockSchema({ validate: async (input) => ({ value: input }) }),
+      });
+      const result = merged['~standard'].validate({
+        body: { foo: 'x' },
+        query: { bar: 1 },
+      });
+      assert.strictEqual(typeof (result as { then?: unknown }).then, 'function');
+      const awaited = (await result) as StandardResult;
+      assert.strictEqual(awaited.issues, undefined);
+    });
+  });
+
+  describe('validate — partial schemas', () => {
+    it('only validates defined slots; rejects undefined slot keys as unexpected', () => {
+      const merged = validationSchemasObjectToSingleValidationSchema({
+        body: z.object({ foo: z.string() }),
+      });
+      const result = merged['~standard'].validate({
+        body: { foo: 'x' },
+        query: { bar: 1 },
+      }) as StandardResult;
+      assert.ok(result.issues);
+      const unexpected = result.issues.find((i) => i.message === 'Unexpected key');
+      assert.deepStrictEqual(unexpected?.path, [{ key: 'query' }]);
+    });
+  });
+
+  describe('jsonSchema.input', () => {
+    it('returns top-level envelope with delegated slot properties', () => {
+      const bodySlot = makeMockSchema({ input: () => ({ type: 'object', tag: 'body' }) });
+      const querySlot = makeMockSchema({ input: () => ({ type: 'object', tag: 'query' }) });
+      const merged = validationSchemasObjectToSingleValidationSchema({
+        body: bodySlot,
+        query: querySlot,
+      });
+      const schema = merged['~standard'].jsonSchema.input({ target: 'draft-2020-12' });
+      assert.strictEqual(schema.type, 'object');
+      assert.strictEqual(schema.additionalProperties, false);
+      assert.deepStrictEqual(schema.required, ['body', 'query']);
+      const properties = schema.properties as Record<string, Record<string, unknown>>;
+      assert.deepStrictEqual(properties.body, { type: 'object', tag: 'body' });
+      assert.deepStrictEqual(properties.query, { type: 'object', tag: 'query' });
+    });
+
+    it('required lists only defined slots', () => {
+      const merged = validationSchemasObjectToSingleValidationSchema({
+        body: makeMockSchema({}),
+      });
+      const schema = merged['~standard'].jsonSchema.input({ target: 'draft-2020-12' });
+      assert.deepStrictEqual(schema.required, ['body']);
+    });
+
+    it('falls back to {} for slots without ~standard.jsonSchema (e.g. Zod 4)', () => {
+      const merged = validationSchemasObjectToSingleValidationSchema({
+        body: z.object({ foo: z.string() }),
+      });
+      const schema = merged['~standard'].jsonSchema.input({ target: 'draft-2020-12' });
+      const properties = schema.properties as Record<string, Record<string, unknown>>;
+      assert.deepStrictEqual(properties.body, {});
+    });
+
+    it('propagates the target option to slot delegations', () => {
+      const slot = makeMockSchema({
+        input: (target) => ({ marker: 'input', target }),
+      });
+      const merged = validationSchemasObjectToSingleValidationSchema({ body: slot });
+      const schema = merged['~standard'].jsonSchema.input({ target: 'draft-07' });
+      const properties = schema.properties as Record<string, Record<string, unknown>>;
+      assert.deepStrictEqual(properties.body, { marker: 'input', target: 'draft-07' });
+    });
+  });
+
+  describe('jsonSchema.output', () => {
+    it('delegates to each slot’s output method (distinct from input)', () => {
+      const slot = makeMockSchema({
+        input: () => ({ shape: 'IN' }),
+        output: () => ({ shape: 'OUT' }),
+      });
+      const merged = validationSchemasObjectToSingleValidationSchema({ body: slot });
+      const inputJSON = merged['~standard'].jsonSchema.input({ target: 'draft-2020-12' });
+      const outputJSON = merged['~standard'].jsonSchema.output({ target: 'draft-2020-12' });
+      const inputProps = inputJSON.properties as Record<string, Record<string, unknown>>;
+      const outputProps = outputJSON.properties as Record<string, Record<string, unknown>>;
+      assert.deepStrictEqual(inputProps.body, { shape: 'IN' });
+      assert.deepStrictEqual(outputProps.body, { shape: 'OUT' });
+    });
+  });
+
+  describe('jsonSchema — no slots', () => {
+    it('returns the empty-properties envelope', () => {
+      const merged = validationSchemasObjectToSingleValidationSchema({});
+      const schema = merged['~standard'].jsonSchema.input({ target: 'draft-2020-12' });
+      assert.deepStrictEqual(schema, {
+        type: 'object',
+        properties: {},
+        required: [],
+        additionalProperties: false,
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an internal helper that merges optional `{ body, query, params }` `CombinedSpec`s into a single `CombinedSpec` whose `~standard` interface conforms to **Standard Schema** + **Standard JSON Schema**.

- Top-level shape validation is handled here: rejects non-objects, reports missing slots as `Required` with `path: [{ key }]`, rejects unknown keys as `Unexpected key`, aggregates all top-level issues (no short-circuit).
- Per-slot value validation is **piped down** to the slot's own `'~standard'.validate(...)`. Issue paths from a slot are prefixed with `{ key: slot }` so callers can pinpoint which slot failed.
- Sync stays sync; if any slot returns a `Promise`, the combined `validate` returns a `Promise` (thenable check, no `await` overhead for the all-sync case).
- JSON Schema envelope is built here as `{ type: 'object', properties, required, additionalProperties: false }`. Per-slot `jsonSchema.input` / `.output` are piped down to the slot. Falls back to `{}` when a slot doesn't expose `~standard.jsonSchema` — matches the existing graceful pattern in [packages/vovk/src/validation/procedure.ts](packages/vovk/src/validation/procedure.ts).
- Slot vendor: `'vovk'`.
- Exposed via `vovk/internal` only — no public API surface change. This is the prerequisite for unifying `inputSchema` on derived and non-derived tools in a follow-up.

## Test plan

- [x] New test file at [test/src/common/validationSchemasObjectToSingleValidationSchema.test.ts](test/src/common/validationSchemasObjectToSingleValidationSchema.test.ts) — 22 cases covering Standard Schema spec compliance, top-level shape rejection, key presence + strict-rejection, slot delegation, sync/async preservation, partial schemas, JSON Schema envelope, target propagation, input/output divergence, missing-`jsonSchema` fallback, and the no-slots empty case
- [x] Local run: `NODE_ENV=test node --experimental-strip-types --test ./test/src/common/validationSchemasObjectToSingleValidationSchema.test.ts` — 22/22 passing
- [x] `npm run build --prefix packages/vovk` clean
- [x] `npm run tsc --prefix packages/vovk` clean
- [x] No new errors from `tsc --project ./test` (pre-existing errors in `WithValidationDecorateController*` and `test/vovk.config.cjs` are unchanged on `origin/main`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validation schema combiner that merges multiple slot schemas (body, query, params) into a single validation specification. Enforces strict validation with required slot checks, rejects unexpected keys, and supports both synchronous and asynchronous validation workflows with proper error aggregation and JSON schema generation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/finom/vovk/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->