### PR TITLE
feat: VovkTool extends the standard-tool StandardTool convention

### DIFF
--- a/packages/vovk/src/types/standard-tool.ts
+++ b/packages/vovk/src/types/standard-tool.ts
@@ -1,0 +1,22 @@
+import type { CombinedSpec } from './validation.js';
+
+/**
+ * The `standard-tool` convention type (https://github.com/finom/standard-tool) — a neutral,
+ * framework-agnostic LLM tool shape. Vendored here as a **type only** (no function logic) so Vovk
+ * keeps zero extra dependencies and {@link import('./tools.js').VovkTool} can structurally `extend`
+ * it: a VovkTool *is* a StandardTool. Kept aligned with the published package — `name` +
+ * `description` + optional Standard-Schema/JSON-Schema `inputSchema`/`outputSchema` +
+ * `execute(input): ModelOutput`.
+ *
+ * `Input`/`Output` are the data the tool accepts and returns; `ModelOutput` is what `execute` returns
+ * to the model after formatting (by default the data, or an `{ error }` envelope). The formatter
+ * itself is an implementation detail of each producer (Vovk's `toModelOutput`, standard-tool's
+ * `formatOutput`), not part of this shape.
+ */
+export interface StandardTool<Input, Output, ModelOutput = Output | { error: string }> {
+  name: string;
+  description: string;
+  inputSchema?: CombinedSpec<Input>;
+  outputSchema?: CombinedSpec<Output>;
+  execute(input: Input): ModelOutput | Promise<ModelOutput>;
+}

--- a/packages/vovk/src/types/standard-tool.ts
+++ b/packages/vovk/src/types/standard-tool.ts
@@ -1,22 +1,14 @@
 import type { CombinedSpec } from './validation.js';
 
 /**
- * The `standard-tool` convention type (https://github.com/finom/standard-tool) — a neutral,
- * framework-agnostic LLM tool shape. Vendored here as a **type only** (no function logic) so Vovk
- * keeps zero extra dependencies and {@link import('./tools.js').VovkTool} can structurally `extend`
- * it: a VovkTool *is* a StandardTool. Kept aligned with the published package — `name` +
- * `description` + optional Standard-Schema/JSON-Schema `inputSchema`/`outputSchema` +
- * `execute(input): ModelOutput`.
- *
- * `Input`/`Output` are the data the tool accepts and returns; `ModelOutput` is what `execute` returns
- * to the model after formatting (by default the data, or an `{ error }` envelope). The formatter
- * itself is an implementation detail of each producer (Vovk's `toModelOutput`, standard-tool's
- * `formatOutput`), not part of this shape.
+ * The `standard-tool` convention (https://github.com/finom/standard-tool): a neutral LLM tool shape —
+ * `name`, `description`, optional `inputSchema`/`outputSchema`, `execute`. Vendored as a type only
+ * (no logic) so `VovkTool` can extend it with zero added dependencies.
  */
-export interface StandardTool<Input, Output, ModelOutput = Output | { error: string }> {
+export interface StandardTool<Input, Output, FormattedOutput = Output | { error: string }> {
   name: string;
   description: string;
   inputSchema?: CombinedSpec<Input>;
   outputSchema?: CombinedSpec<Output>;
-  execute(input: Input): ModelOutput | Promise<ModelOutput>;
+  execute(input: Input): FormattedOutput | Promise<FormattedOutput>;
 }

--- a/packages/vovk/src/types/tools.ts
+++ b/packages/vovk/src/types/tools.ts
@@ -1,6 +1,7 @@
 import type { VovkJSONSchemaBase } from './json-schema.js';
 import type { VovkRequest } from './request.js';
 import type { CombinedSpec } from './validation.js';
+import type { StandardTool } from './standard-tool.js';
 import type { KnownAny } from './utils.js';
 
 export type ToModelOutputFn<TInput, TOutput, TFormattedOutput> = (
@@ -12,9 +13,15 @@ export type ToModelOutputFn<TInput, TOutput, TFormattedOutput> = (
 /**
  * Vovk tool — produced by both `deriveTools` (procedures → tools) and
  * `createTool` (standalone tools). Both call sites return the same shape.
+ *
+ * Structurally a {@link StandardTool} (https://github.com/finom/standard-tool): a VovkTool *is* a
+ * standard tool, extended with Vovk specifics (`title`, JSON-Schema `parameters`, per-slot
+ * `inputSchemas`, `type`). Vovk applies its output formatter (`toModelOutput`) internally, so it is
+ * not part of the shared shape.
  * @see https://vovk.dev/tools
  */
-export interface VovkTool<TInput = KnownAny, TOutput = KnownAny, TFormattedOutput = KnownAny> {
+export interface VovkTool<TInput = KnownAny, TOutput = KnownAny, TFormattedOutput = KnownAny>
+  extends StandardTool<TInput, TOutput, TFormattedOutput> {
   execute: (input: TInput, options?: unknown) => TFormattedOutput | Promise<TFormattedOutput>;
   name: string;
   title: string | undefined;

--- a/packages/vovk/src/types/tools.ts
+++ b/packages/vovk/src/types/tools.ts
@@ -12,12 +12,8 @@ export type ToModelOutputFn<TInput, TOutput, TFormattedOutput> = (
 
 /**
  * Vovk tool — produced by both `deriveTools` (procedures → tools) and
- * `createTool` (standalone tools). Both call sites return the same shape.
- *
- * Structurally a {@link StandardTool} (https://github.com/finom/standard-tool): a VovkTool *is* a
- * standard tool, extended with Vovk specifics (`title`, JSON-Schema `parameters`, per-slot
- * `inputSchemas`, `type`). Vovk applies its output formatter (`toModelOutput`) internally, so it is
- * not part of the shared shape.
+ * `createTool` (standalone tools); both return the same shape. Extends the
+ * {@link StandardTool} convention with Vovk specifics (`title`, `parameters`, `type`).
  * @see https://vovk.dev/tools
  */
 export interface VovkTool<TInput = KnownAny, TOutput = KnownAny, TFormattedOutput = KnownAny>


### PR DESCRIPTION
## What

Adds `packages/vovk/src/types/standard-tool.ts` — a **type-only** vendoring of the
[`standard-tool`](https://github.com/finom/standard-tool) convention — and makes `VovkTool`
structurally extend it:

```ts
export interface VovkTool<TInput, TOutput, TFormattedOutput>
  extends StandardTool<TInput, TOutput, TFormattedOutput> { /* …Vovk specifics… */ }
```

## Why

`standard-tool` is a small, framework-agnostic LLM-tool shape: `name` + `description` + optional
Standard-Schema/JSON-Schema `inputSchema`/`outputSchema` + `execute(input): ModelOutput`. Declaring
`VovkTool extends StandardTool` states the relationship at the type level — a VovkTool *is* a
standard tool, plus Vovk specifics (`title`, JSON-Schema `parameters`, per-slot `inputSchemas`,
`type`).

## Notes

- **Public shape unchanged** — VovkTool only gains a supertype.
- Compatible because StandardTool's `inputSchema`/`outputSchema` are **optional** (assignable from
  VovkTool's conditional schema fields) and StandardTool has **no formatter member** — Vovk's
  `toModelOutput` stays internal; the 3rd generic is just the formatted-output type.
- Type/JSDoc only; no runtime code changes.

Builds on #16 (already merged).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Introduced a standardized tool interface and updated the existing tool shape to align with it, improving type consistency, interoperability, and uniform behavior across tool implementations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/finom/vovk/pull/18?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->