### PR TITLE
feat(tools): forward per-call meta to tool execute; VovkTool inherits it from StandardTool

### DIFF
--- a/packages/vovk/src/tools/createToolFactory.ts
+++ b/packages/vovk/src/tools/createToolFactory.ts
@@ -63,7 +63,7 @@ export function createToolFactory({
     options: CreateToolBaseOptions<TInput, TOutput, InferFormattedOutput<TToModelOutput, TOutput>> &
       WithInputSchema<TInput> &
       WithOutputSchema<TOutput> & {
-        execute: (input: TInput, processingMeta?: unknown) => TOutput | Promise<TOutput>;
+        execute: (input: TInput, processingMeta?: KnownAny) => TOutput | Promise<TOutput>;
         toModelOutput: TToModelOutput;
       }
   ): CreateToolResult<TInput, TOutput, InferFormattedOutput<TToModelOutput, TOutput>>;
@@ -73,7 +73,7 @@ export function createToolFactory({
     options: CreateToolBaseOptions<TInput, TOutput, DefaultModelOutput<TOutput>> &
       WithInputSchema<TInput> &
       WithOutputSchema<TOutput> & {
-        execute: (input: TInput, processingMeta?: unknown) => TOutput | Promise<TOutput>;
+        execute: (input: TInput, processingMeta?: KnownAny) => TOutput | Promise<TOutput>;
         toModelOutput?: undefined;
       }
   ): CreateToolResult<TInput, TOutput, DefaultModelOutput<TOutput>>;
@@ -83,7 +83,7 @@ export function createToolFactory({
     options: CreateToolBaseOptions<TInput, TOutput, InferFormattedOutput<TToModelOutput, TOutput>> &
       WithInputSchema<TInput> &
       WithoutOutputSchema & {
-        execute: (input: TInput, processingMeta?: unknown) => TOutput | Promise<TOutput>;
+        execute: (input: TInput, processingMeta?: KnownAny) => TOutput | Promise<TOutput>;
         toModelOutput: TToModelOutput;
       }
   ): CreateToolResult<TInput, TOutput, InferFormattedOutput<TToModelOutput, TOutput>>;
@@ -93,7 +93,7 @@ export function createToolFactory({
     options: CreateToolBaseOptions<TInput, TOutput, DefaultModelOutput<TOutput>> &
       WithInputSchema<TInput> &
       WithoutOutputSchema & {
-        execute: (input: TInput, processingMeta?: unknown) => TOutput | Promise<TOutput>;
+        execute: (input: TInput, processingMeta?: KnownAny) => TOutput | Promise<TOutput>;
         toModelOutput?: undefined;
       }
   ): CreateToolResult<TInput, TOutput, DefaultModelOutput<TOutput>>;
@@ -103,7 +103,7 @@ export function createToolFactory({
     options: CreateToolBaseOptions<null, TOutput, InferFormattedOutput<TToModelOutput, TOutput>> &
       WithoutInputSchema &
       WithOutputSchema<TOutput> & {
-        execute: (input: null, processingMeta?: unknown) => TOutput | Promise<TOutput>;
+        execute: (input: null, processingMeta?: KnownAny) => TOutput | Promise<TOutput>;
         toModelOutput: TToModelOutput;
       }
   ): CreateToolResult<null, TOutput, InferFormattedOutput<TToModelOutput, TOutput>>;
@@ -113,7 +113,7 @@ export function createToolFactory({
     options: CreateToolBaseOptions<null, TOutput, DefaultModelOutput<TOutput>> &
       WithoutInputSchema &
       WithOutputSchema<TOutput> & {
-        execute: (input: null, processingMeta?: unknown) => TOutput | Promise<TOutput>;
+        execute: (input: null, processingMeta?: KnownAny) => TOutput | Promise<TOutput>;
         toModelOutput?: undefined;
       }
   ): CreateToolResult<null, TOutput, DefaultModelOutput<TOutput>>;
@@ -123,7 +123,7 @@ export function createToolFactory({
     options: CreateToolBaseOptions<null, TOutput, InferFormattedOutput<TToModelOutput, TOutput>> &
       WithoutInputSchema &
       WithoutOutputSchema & {
-        execute: (input: null, processingMeta?: unknown) => TOutput | Promise<TOutput>;
+        execute: (input: null, processingMeta?: KnownAny) => TOutput | Promise<TOutput>;
         toModelOutput: TToModelOutput;
       }
   ): CreateToolResult<null, TOutput, InferFormattedOutput<TToModelOutput, TOutput>>;
@@ -133,7 +133,7 @@ export function createToolFactory({
     options: CreateToolBaseOptions<null, TOutput, DefaultModelOutput<TOutput>> &
       WithoutInputSchema &
       WithoutOutputSchema & {
-        execute: (input: null, processingMeta?: unknown) => TOutput | Promise<TOutput>;
+        execute: (input: null, processingMeta?: KnownAny) => TOutput | Promise<TOutput>;
         toModelOutput?: undefined;
       }
   ): CreateToolResult<null, TOutput, DefaultModelOutput<TOutput>>;
@@ -153,7 +153,7 @@ export function createToolFactory({
   }: CreateToolBaseOptions<TInput, TOutput, TFormattedOutput> & {
     inputSchema?: CombinedSpec<TInput>;
     outputSchema?: CombinedSpec<TOutput>;
-    execute: (input: KnownAny, processingMeta?: unknown) => TOutput | Promise<TOutput>;
+    execute: (input: KnownAny, processingMeta?: KnownAny) => TOutput | Promise<TOutput>;
     toModelOutput?: ToModelOutputFn<TInput, TOutput, TFormattedOutput>;
   }): VovkTool<TInput, TOutput, TFormattedOutput> {
     let parameters: unknown;

--- a/packages/vovk/src/types/standard-tool.ts
+++ b/packages/vovk/src/types/standard-tool.ts
@@ -1,14 +1,16 @@
 import type { CombinedSpec } from './validation.js';
+import type { KnownAny } from './utils.js';
 
 /**
  * The `standard-tool` convention (https://github.com/finom/standard-tool): a neutral LLM tool shape —
  * `name`, `description`, optional `inputSchema`/`outputSchema`, `execute`. Vendored as a type only
- * (no logic) so `VovkTool` can extend it with zero added dependencies.
+ * (no logic) so `VovkTool` can extend it with zero added dependencies. Kept identical to the
+ * `StandardTool` type published by `standard-tool` (`meta` is `KnownAny`, i.e. its `any`).
  */
 export interface StandardTool<Input, Output, FormattedOutput = Output | { error: string }> {
   name: string;
   description: string;
   inputSchema?: CombinedSpec<Input>;
   outputSchema?: CombinedSpec<Output>;
-  execute(input: Input): FormattedOutput | Promise<FormattedOutput>;
+  execute(input: Input, meta?: KnownAny): FormattedOutput | Promise<FormattedOutput>;
 }

--- a/packages/vovk/src/types/tools.ts
+++ b/packages/vovk/src/types/tools.ts
@@ -18,7 +18,6 @@ export type ToModelOutputFn<TInput, TOutput, TFormattedOutput> = (
  */
 export interface VovkTool<TInput = KnownAny, TOutput = KnownAny, TFormattedOutput = KnownAny>
   extends StandardTool<TInput, TOutput, TFormattedOutput> {
-  execute: (input: TInput, options?: unknown) => TFormattedOutput | Promise<TFormattedOutput>;
   name: string;
   title: string | undefined;
   description: string;


### PR DESCRIPTION
## What

Mirrors the [`standard-tool`](https://github.com/finom/standard-tool) `execute(input, meta?)` design onto vovk, and collapses `VovkTool`'s bespoke `execute` into the inherited one.

- **`types/standard-tool.ts`** — `execute(input, meta?: KnownAny)` added to the vendored `StandardTool`. Keeps vovk's `StandardTool` type **identical** to the `standard-tool` package's (`meta` is `KnownAny` = its `any`; `CombinedSpec` ≡ its `CombinedSchema`).
- **`types/tools.ts`** — `VovkTool` drops its `execute: (input, options?: unknown) => …` override and **inherits** `execute(input, meta?)` from `StandardTool`. Removes the duplication and upgrades the second arg `unknown → KnownAny`.
- **`tools/createToolFactory.ts`** — author-side `processingMeta?: unknown → KnownAny` (all 8 overloads + impl), so handlers can annotate the per-call meta type (e.g. `execute: (input, meta: MyCtx) => …`), exactly like standard-tool.

## Why

Per-call runtime context (auth tokens, resolvers, request-scoped data) must not live in the LLM-facing `inputSchema`. vovk already forwards `processingMeta` at runtime; this aligns the *types* with the standard-tool convention and removes drift between the two `StandardTool` definitions.

## Verification

`npm --prefix packages/vovk run build`, `tsc --noEmit` (exit 0), and `biome check` on the changed files all pass. Folds into the not-yet-published 3.3.0. Backward-compatible (widening only).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced tool execution signatures to support optional metadata parameters across all tool variants.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/finom/vovk/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->