### PR TITLE
refactor(types): default StandardTool generics to unknown; VovkTool inherits name/description

### DIFF
--- a/packages/vovk/src/types/standard-tool.ts
+++ b/packages/vovk/src/types/standard-tool.ts
@@ -7,7 +7,7 @@ import type { KnownAny } from './utils.js';
  * (no logic) so `VovkTool` can extend it with zero added dependencies. Kept identical to the
  * `StandardTool` type published by `standard-tool` (`meta` is `KnownAny`, i.e. its `any`).
  */
-export interface StandardTool<Input, Output, FormattedOutput = Output | { error: string }> {
+export interface StandardTool<Input = unknown, Output = unknown, FormattedOutput = Output | { error: string }> {
   name: string;
   description: string;
   inputSchema?: CombinedSpec<Input>;

--- a/packages/vovk/src/types/tools.ts
+++ b/packages/vovk/src/types/tools.ts
@@ -18,9 +18,7 @@ export type ToModelOutputFn<TInput, TOutput, TFormattedOutput> = (
  */
 export interface VovkTool<TInput = KnownAny, TOutput = KnownAny, TFormattedOutput = KnownAny>
   extends StandardTool<TInput, TOutput, TFormattedOutput> {
-  name: string;
   title: string | undefined;
-  description: string;
   parameters: {
     type?: 'object';
     properties?: {


### PR DESCRIPTION
Keeps vovk's vendored `StandardTool` byte-aligned with the type published by `standard-tool` (0.0.4), which defaults `Input`/`Output` to `unknown`.

- `StandardTool<Input = unknown, Output = unknown, …>` — bare `StandardTool[]` now works (no explicit `<unknown, unknown>`), matching standard-tool 0.0.4.
- `VovkTool` drops its redundant `name`/`description` redeclarations — both are inherited verbatim from `StandardTool`. The deliberate `inputSchema`/`outputSchema` narrowing overrides and the Vovk-specific `title`/`parameters`/`inputSchemas`/`type` stay.

Type-only change; `tsc --noEmit` + biome are green locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Tool type definitions now include default generic parameters, simplifying implementation without requiring explicit type arguments in standard use cases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/finom/vovk/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->