### PR TITLE
feat(openapi): add filterOperations + pruneComponents for OpenAPI mixins

### DIFF
--- a/packages/vovk/src/openapi/openAPIToVovkSchema/index.ts
+++ b/packages/vovk/src/openapi/openAPIToVovkSchema/index.ts
@@ -7,6 +7,7 @@ import type {
 } from 'openapi3-ts/oas31';
 import { applyComponentsSchemas } from './applyComponentsSchemas.js';
 import { inlineRefs } from './inlineRefs.js';
+import { pruneComponentsSchemas } from './pruneComponentsSchemas.js';
 import { type HttpMethod, VovkSchemaIdEnum } from '../../types/enums.js';
 import type { VovkSchema } from '../../types/core.js';
 import type { VovkJSONSchemaBase } from '../../types/json-schema.js';
@@ -39,6 +40,8 @@ export function openAPIToVovkSchema({
   source: { object: openAPIObject },
   getModuleName,
   getMethodName,
+  filterOperations,
+  pruneComponents,
   errorMessageKey,
   segmentName,
 }: VovkOpenAPIMixinNormalized & { segmentName?: string }): VovkSchema {
@@ -73,10 +76,22 @@ export function openAPIToVovkSchema({
   };
   const segment = schema.segments[segmentName];
 
-  return Object.entries(paths ?? {}).reduce((acc, [path, operations]) => {
+  Object.entries(paths ?? {}).forEach(([path, operations]) => {
     Object.entries(operations ?? {})
       .filter(([, operation]) => operation && typeof operation === 'object')
       .forEach(([method, operation]: [string, OperationObject]) => {
+        if (
+          filterOperations &&
+          !filterOperations({
+            method: method.toUpperCase() as HttpMethod,
+            path,
+            openAPIObject,
+            operationObject: operation,
+          })
+        ) {
+          return;
+        }
+
         const rpcModuleName = getModuleName({
           method: method.toUpperCase() as HttpMethod,
           path,
@@ -189,6 +204,23 @@ export function openAPIToVovkSchema({
           },
         };
       });
-    return acc;
-  }, schema);
+  });
+
+  if (pruneComponents && noPathsOpenAPIObject.components?.schemas) {
+    // Reassign with fresh objects only — `noPathsOpenAPIObject` shares references with the
+    // caller's spec, so the original `components.schemas` must stay untouched. Walking the
+    // whole controllers tree (validation slots + raw operation objects) keeps every `$ref`
+    // a kept handler carries resolvable against the pruned meta.
+    segment.meta = {
+      openAPIObject: {
+        ...noPathsOpenAPIObject,
+        components: {
+          ...noPathsOpenAPIObject.components,
+          schemas: pruneComponentsSchemas(segment.controllers, noPathsOpenAPIObject.components.schemas),
+        },
+      },
+    };
+  }
+
+  return schema;
 }

--- a/packages/vovk/src/openapi/openAPIToVovkSchema/pruneComponentsSchemas.ts
+++ b/packages/vovk/src/openapi/openAPIToVovkSchema/pruneComponentsSchemas.ts
@@ -1,0 +1,53 @@
+import type { ComponentsObject } from 'openapi3-ts/oas31';
+
+// Collect the trailing name of every `$ref` in the tree. Covers both pointer styles
+// the transform emits: `#/components/schemas/X` (response slots, raw operation objects)
+// and `#/$defs/X` (request slots embed components under their original names).
+function collectRefNames(node: unknown, into: Set<string>): void {
+  if (!node || typeof node !== 'object') return;
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectRefNames(item, into);
+    }
+    return;
+  }
+  for (const [key, value] of Object.entries(node)) {
+    if (key === '$ref' && typeof value === 'string') {
+      const name = value.split('/').pop();
+      if (name) into.add(name);
+    } else {
+      collectRefNames(value, into);
+    }
+  }
+}
+
+/**
+ * Shrinks a `components.schemas` dict to the transitive `$ref` closure of `roots`
+ * (BFS with a visited set — component graphs of large specs like Stripe are cyclic).
+ * Preserves the original key order for deterministic output.
+ */
+export function pruneComponentsSchemas(
+  roots: unknown,
+  componentsSchemas: NonNullable<ComponentsObject['schemas']>
+): NonNullable<ComponentsObject['schemas']> {
+  const required = new Set<string>();
+  collectRefNames(roots, required);
+  const queue = [...required];
+  const visited = new Set<string>();
+
+  while (queue.length) {
+    const name = queue.pop();
+    if (!name || visited.has(name)) continue;
+    visited.add(name);
+    const component = componentsSchemas[name];
+    if (!component) continue;
+    const refs = new Set<string>();
+    collectRefNames(component, refs);
+    for (const ref of refs) {
+      required.add(ref);
+      if (!visited.has(ref)) queue.push(ref);
+    }
+  }
+
+  return Object.fromEntries(Object.entries(componentsSchemas).filter(([name]) => required.has(name)));
+}

--- a/packages/vovk/src/types/config.ts
+++ b/packages/vovk/src/types/config.ts
@@ -111,6 +111,17 @@ export interface VovkOpenAPIMixin {
     | 'camel-case-operation-id' // operation ID to camelCase
     | 'auto' // auto-detect based on operationObject method and path
     | GetOpenAPINameFn;
+  /**
+   * Keep only operations the predicate returns `true` for; omitted = keep all. Runs before
+   * `getModuleName`/`getMethodName`, so a module whose operations are all filtered out is never created.
+   */
+  filterOperations?: (config: Parameters<GetOpenAPINameFn>[0]) => boolean;
+  /**
+   * Prune `meta.openAPIObject.components.schemas` to the transitive `$ref` closure of the kept operations,
+   * shrinking the generated schema for large specs. Removes `Mixins.<Segment>.<Component>` types for
+   * components nothing kept references — keep `false` (default) if you import such types directly.
+   */
+  pruneComponents?: boolean;
   errorMessageKey?: string;
   mixinName?: string;
 }

--- a/test/src/common/openAPIToVovkSchema.test.ts
+++ b/test/src/common/openAPIToVovkSchema.test.ts
@@ -38,11 +38,12 @@ const spec = {
       },
       Nested: { type: 'object', properties: { value: { type: 'number' } } },
       CreateThing: { type: 'object', properties: { name: { type: 'string' } } },
+      Orphan: { type: 'object', properties: { unused: { type: 'boolean' } } },
     },
   },
 };
 
-function build() {
+function build(extra: Obj = {}) {
   return openAPIToVovkSchema({
     apiRoot: 'https://api.example.com',
     source: { object: spec },
@@ -50,6 +51,7 @@ function build() {
     getMethodName: ({ operationObject }: { operationObject: { operationId?: string } }) =>
       operationObject.operationId ?? 'op',
     segmentName: 'api',
+    ...extra,
   } as unknown as Parameters<typeof openAPIToVovkSchema>[0]);
 }
 
@@ -112,5 +114,94 @@ describe('reattachMixinDefs — render-time reconstitution (Rust)', () => {
     const slot = { $ref: '#/components/schemas/Shared', 'x-tsType': 'Mixins.Api.Shared' } as Obj;
     const out = reattachMixinDefs(slot, { segmentType: 'segment', segmentName: 'x' });
     strictEqual(out, slot, 'returns the slot unchanged for non-mixin segments');
+  });
+});
+
+describe('openAPIToVovkSchema — filterOperations', () => {
+  it('keeps only operations the predicate accepts (by method)', () => {
+    const segment = build({ filterOperations: ({ method }: Obj) => method === 'GET' }).segments.api as Seg;
+    const handlers = segment.controllers.Test.handlers;
+    deepStrictEqual(Object.keys(handlers).sort(), ['getThings', 'streamThings'], 'POST createThing is absent');
+  });
+
+  it('keeps only operations the predicate accepts (by path)', () => {
+    const segment = build({ filterOperations: ({ path }: Obj) => path === '/stream' }).segments.api as Seg;
+    const handlers = segment.controllers.Test.handlers;
+    deepStrictEqual(Object.keys(handlers), ['streamThings'], 'only the /stream operation survives');
+  });
+
+  it('never creates a module whose operations are all filtered out', () => {
+    const segment = build({ filterOperations: () => false }).segments.api as Seg;
+    deepStrictEqual(segment.controllers, {}, 'no empty controller entries');
+  });
+
+  it('defaults (no filter, no prune) keep every operation and every component', () => {
+    const segment = build().segments.api as Seg;
+    deepStrictEqual(Object.keys(segment.controllers.Test.handlers).sort(), [
+      'createThing',
+      'getThings',
+      'streamThings',
+    ]);
+    deepStrictEqual(Object.keys(segment.meta.openAPIObject.components.schemas).sort(), [
+      'CreateThing',
+      'Nested',
+      'Orphan',
+      'Shared',
+    ]);
+  });
+});
+
+describe('openAPIToVovkSchema — pruneComponents', () => {
+  it('drops components nothing references, keeps the transitive closure', () => {
+    const segment = build({ pruneComponents: true }).segments.api as Seg;
+    deepStrictEqual(
+      Object.keys(segment.meta.openAPIObject.components.schemas).sort(),
+      ['CreateThing', 'Nested', 'Shared'],
+      'Orphan pruned; Nested kept transitively via Shared'
+    );
+  });
+
+  it('drops components referenced only by filtered-out operations', () => {
+    const segment = build({
+      filterOperations: ({ method }: Obj) => method === 'GET',
+      pruneComponents: true,
+    }).segments.api as Seg;
+    deepStrictEqual(
+      Object.keys(segment.meta.openAPIObject.components.schemas).sort(),
+      ['Nested', 'Shared'],
+      'CreateThing (only used by the filtered-out POST) and Orphan pruned'
+    );
+  });
+
+  it('keeps the response closure of kept operations', () => {
+    const segment = build({
+      filterOperations: ({ method }: Obj) => method === 'POST',
+      pruneComponents: true,
+    }).segments.api as Seg;
+    deepStrictEqual(
+      Object.keys(segment.meta.openAPIObject.components.schemas).sort(),
+      ['CreateThing', 'Nested', 'Shared'],
+      'createThing needs CreateThing (body) and Shared→Nested (its 200 response)'
+    );
+  });
+
+  it('reattachMixinDefs still reconstitutes response slots from the pruned meta', () => {
+    const segment = build({
+      filterOperations: ({ method }: Obj) => method === 'GET',
+      pruneComponents: true,
+    }).segments.api as Seg;
+    const reattached = reattachMixinDefs(segment.controllers.Test.handlers.getThings.validation.output, segment) as Obj;
+    strictEqual(reattached.$ref, '#/$defs/Shared', 'ref rewritten to local $defs');
+    ok(reattached.$defs?.Shared, 'Shared re-embedded after pruning');
+    ok(reattached.$defs?.Nested, 'transitive Nested re-embedded after pruning');
+  });
+
+  it('does not mutate the input spec', () => {
+    build({ filterOperations: () => false, pruneComponents: true });
+    deepStrictEqual(
+      Object.keys(spec.components.schemas).sort(),
+      ['CreateThing', 'Nested', 'Orphan', 'Shared'],
+      'the caller-owned spec keeps its full components dict'
+    );
   });
 });


### PR DESCRIPTION
Two additive, default-off options on `openAPIMixin` for trimming large specs:

- **`filterOperations`** — predicate over `{ operationObject, method, path, openAPIObject }` (same shape as the naming functions); only operations it returns `true` for are generated. Runs before `getModuleName`/`getMethodName`, so a module whose operations are all filtered out is never created.
- **`pruneComponents`** (default `false`) — after the transform, shrinks `meta.openAPIObject.components.schemas` to the transitive `$ref` closure of the kept handlers. The walk covers validation slots *and* the raw `operationObject`s so every serialized ref stays resolvable (`mixins.d.ts` type compilation, `reattachMixinDefs` for the Rust generator, error-response refs). BFS with a visited set (cyclic graphs), original key order preserved, input spec never mutated.

No `vovk-cli` changes: `normalizeOpenAPIMixin` spreads the mixin config through.

Measured on Stripe `spec3.sdk.json` with an 8-GET filter: segment schema 8.38 MB → 2.01 MB (filter) → **1.20 MB** (filter+prune), components 1693 → 863 (Stripe's strongly-connected core).

Tests: 9 new cases in `test/src/common/openAPIToVovkSchema.test.ts` (filter by method/path, empty-module omission, defaults regression, closure pruning in both directions, `reattachMixinDefs` after prune, input-spec immutability). Existing cases untouched.

Note: `npm test` is currently red on `main` (pre-existing; CI failing since May 30 with an assertion error in a late lane). This branch reproduces main's failures identically under stash A/B; all lanes that pass on main pass here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OpenAPI operations can now be filtered based on custom criteria
  * Unused OpenAPI component schemas can optionally be pruned from output

* **Tests**
  * Added test coverage for operation filtering functionality
  * Added test coverage for component schema pruning functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->