### PR TITLE
chore(deps): raise vovk peer floor to >=3.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6475,7 +6475,7 @@
         "ajv-formats": "^3.0.1"
       },
       "peerDependencies": {
-        "vovk": ">=3.0.0"
+        "vovk": ">=3.6.0"
       }
     },
     "packages/vovk-ajv/node_modules/ajv": {
@@ -6556,7 +6556,7 @@
         "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13"
       },
       "peerDependencies": {
-        "vovk": ">=3.0.0"
+        "vovk": ">=3.6.0"
       }
     },
     "packages/vovk-cli/node_modules/@rolldown/binding-linux-x64-gnu": {

--- a/packages/vovk-ajv/package.json
+++ b/packages/vovk-ajv/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://vovk.dev/imports",
   "peerDependencies": {
-    "vovk": ">=3.0.0"
+    "vovk": ">=3.6.0"
   },
   "dependencies": {
     "ajv": "^8.18.0",

--- a/packages/vovk-cli/package.json
+++ b/packages/vovk-cli/package.json
@@ -42,7 +42,7 @@
   },
   "homepage": "https://vovk.dev",
   "peerDependencies": {
-    "vovk": ">=3.0.0"
+    "vovk": ">=3.6.0"
   },
   "optionalDependencies": {
     "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.13"


### PR DESCRIPTION
vovk 3.7.0 is on the registry, so the `>=3.6.0` peer range in vovk-cli and vovk-ajv is registry-satisfiable — this completes the two-stage peer bump deferred in #23 (declaring it before publish hung bun's resolver in CI). Generated clients import `vovk/create-rpc`, which ships in vovk 3.7.0; no 3.6.x will ever exist on the registry, so the effective floor is 3.7.0.

To be merged before vovk-ajv/vovk-cli are published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum vovk peer dependency requirement to `>=3.6.0` in vovk-ajv and vovk-cli packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->