### PR TITLE
fix(cli): scaffold force-static for static segments

### DIFF
--- a/packages/vovk-cli/src/new/new-segment.mts
+++ b/packages/vovk-cli/src/new/new-segment.mts
@@ -44,6 +44,8 @@ export type Controllers = typeof controllers;
 ${
   isStaticSegment
     ? `
+export const dynamic = 'force-static';
+
 export function generateStaticParams() {
   return controllersToStaticParams(controllers);
 }

--- a/packages/vovk-cli/test/spec/new/new-segment.test.mts
+++ b/packages/vovk-cli/test/spec/new/new-segment.test.mts
@@ -72,6 +72,7 @@ await describe('CLI new segment', async () => {
     });
     await runAtProjectDir('../dist/index.mjs new segment foo --static');
     await assertFile('src/app/api/foo/[[...vovk]]/route.ts', [
+      `export const dynamic = 'force-static';`,
       `export function generateStaticParams() {`,
       `export const { GET } = initSegment({
         segmentName: 'foo',
@@ -96,6 +97,7 @@ await describe('CLI new segment', async () => {
     );
 
     await assertFile('src/app/api/bar/baz/qwe/[[...vovk]]/route.ts', `export function generateStaticParams() {`, true);
+    await assertFile('src/app/api/bar/baz/qwe/[[...vovk]]/route.ts', `export const dynamic = 'force-static';`, true);
   });
 
   await it('Multiple new segments', async () => {


### PR DESCRIPTION
## Problem

Next.js 16 defaults Route Handlers to **dynamic**. So a static segment scaffolded by `vovk new segment --static` — which relies on `generateStaticParams` + `controllersToStaticParams` to pre-render endpoints under `output: 'export'` — silently stops being pre-rendered. The route is marked `ƒ` (dynamic) instead of `●`, nothing lands in `out/`, and every endpoint 404s on static hosting (GitHub Pages, etc.).

This was observed on vovk.dev: `/api/hello/greeting.json` and the schema endpoints all 404'd in production.

## Fix

Emit `export const dynamic = 'force-static'` in the static-segment template. The route flips back to `●` (prerendered) and the JSON files export as expected. Non-static segments are unaffected.

## Verification
- `vovk new segment foo --static` now scaffolds `force-static`; non-static segments do not.
- `new-segment` test suite: 8/8 pass (added assertions for presence/absence).