### PR TITLE
feat(tools): retire toolsByName, deriveTools returns the tools array

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
       - main
+      - v4
   pull_request:
     branches:
       - main
+      - v4
   workflow_dispatch:
 
 jobs:

--- a/packages/vovk/src/tools/derive-tools.ts
+++ b/packages/vovk/src/tools/derive-tools.ts
@@ -189,12 +189,6 @@ type DeriveToolsBaseOptions<TOutput = unknown, TFormattedOutput = unknown> = {
   ) => void;
 };
 
-// Return type helper
-type DeriveToolsResult<TOutput, TFormattedOutput> = {
-  tools: StandardToolV0<DerivedToolInput, TOutput, TFormattedOutput>[];
-  toolsByName: Record<string, StandardToolV0<DerivedToolInput, TOutput, TFormattedOutput>>;
-};
-
 /**
  * Derives AI tools from controllers and RPC modules.
  * @see https://vovk.dev/tools
@@ -203,7 +197,7 @@ type DeriveToolsResult<TOutput, TFormattedOutput> = {
  * import { deriveTools, ToModelOutput } from 'vovk';
  * import { UserRPC } from 'vovk-client';
  *
- * const { tools, toolsByName } = deriveTools({
+ * const tools = deriveTools({
  *   modules: { UserRPC },
  *   toModelOutput: ToModelOutput.MCP,
  *   onExecute: (result, tool) => {
@@ -220,14 +214,14 @@ export function deriveTools<TOutput = unknown, TFormattedOutput = DefaultModelOu
   options: DeriveToolsBaseOptions & {
     toModelOutput?: never;
   }
-): DeriveToolsResult<TOutput, TFormattedOutput>;
+): StandardToolV0<DerivedToolInput, TOutput, TFormattedOutput>[];
 
 // Overload: with toModelOutput - infers TFormattedOutput from the function
 export function deriveTools<TOutput = unknown, TFormattedOutput = unknown>(
   options: DeriveToolsBaseOptions & {
     toModelOutput: ToModelOutputFn<unknown, TOutput, TFormattedOutput>;
   }
-): DeriveToolsResult<TOutput, TFormattedOutput>;
+): StandardToolV0<DerivedToolInput, TOutput, TFormattedOutput>[];
 
 export function deriveTools<TOutput = unknown, TFormattedOutput = unknown>(options: {
   modules: Record<string, object>;
@@ -243,7 +237,7 @@ export function deriveTools<TOutput = unknown, TFormattedOutput = unknown>(optio
     tool: StandardToolV0<DerivedToolInput, TOutput, TFormattedOutput>,
     req: Pick<VovkRequest, 'vovk'> | null
   ) => void;
-}): DeriveToolsResult<TOutput, TFormattedOutput> {
+}): StandardToolV0<DerivedToolInput, TOutput, TFormattedOutput>[] {
   const {
     modules,
     meta,
@@ -252,7 +246,7 @@ export function deriveTools<TOutput = unknown, TFormattedOutput = unknown>(optio
     onError = () => {},
   } = options;
 
-  const tools = Object.entries(
+  return Object.entries(
     (modules as Record<string, Record<string, Handler & { schema?: VovkHandlerSchema }>>) ?? {}
   ).flatMap(([moduleName, module]) => {
     return Object.entries(module ?? {})
@@ -271,9 +265,4 @@ export function deriveTools<TOutput = unknown, TFormattedOutput = unknown>(optio
         })
       );
   });
-  const toolsByName = Object.fromEntries(tools.map((tool) => [tool.name, tool]));
-  return {
-    tools,
-    toolsByName,
-  };
 }

--- a/test/src/common/derive-tools-rpc.test.ts
+++ b/test/src/common/derive-tools-rpc.test.ts
@@ -4,9 +4,14 @@ import { deriveTools } from 'vovk';
 import { OpenApiControllerRPC, WithValidationRPC } from 'vovk-client';
 
 describe('deriveTools from RPC modules', () => {
-  const { toolsByName } = deriveTools({
+  const tools = deriveTools({
     modules: { WithValidationRPC, OpenApiControllerRPC },
   });
+
+  const handleAllTool = tools.find(({ name }) => name === 'WithValidationRPC_handleAll');
+  if (!handleAllTool) {
+    throw new Error('Test precondition failed: the WithValidationRPC_handleAll tool must be derived');
+  }
 
   const validation = WithValidationRPC.handleAll.schema.validation;
   if (!validation?.body || !validation.query || !validation.params || !validation.output) {
@@ -14,7 +19,7 @@ describe('deriveTools from RPC modules', () => {
   }
 
   it('Reconstructs inputSchema from the JSON Schemas emitted to the RPC module schema', () => {
-    const tool = toolsByName.WithValidationRPC_handleAll;
+    const tool = handleAllTool;
     assert.ok(tool.inputSchema, 'expected inputSchema to be defined for an RPC-derived tool');
     assert.strictEqual(tool.inputSchema['~standard'].vendor, 'vovk');
     assert.strictEqual(tool.inputSchema['~standard'].version, 1);
@@ -34,7 +39,7 @@ describe('deriveTools from RPC modules', () => {
   });
 
   it('Reconstructs outputSchema from the output JSON Schema emitted to the RPC module schema', () => {
-    const tool = toolsByName.WithValidationRPC_handleAll;
+    const tool = handleAllTool;
     assert.ok(tool.outputSchema, 'expected outputSchema to be defined for an RPC-derived tool');
     assert.strictEqual(tool.outputSchema['~standard'].vendor, 'vovk');
     assert.strictEqual(tool.outputSchema['~standard'].version, 1);
@@ -49,7 +54,7 @@ describe('deriveTools from RPC modules', () => {
   });
 
   it('Reconstructed inputSchema validates the envelope and lets slot contents pass', async () => {
-    const spec = toolsByName.WithValidationRPC_handleAll.inputSchema?.['~standard'];
+    const spec = handleAllTool.inputSchema?.['~standard'];
     assert.ok(spec);
     // slot contents are not checked here, the server validates them during execute
     const input = { body: { hello: 42 }, query: {}, params: {} };
@@ -69,14 +74,14 @@ describe('deriveTools from RPC modules', () => {
   });
 
   it('Reconstructed outputSchema always passes validate', async () => {
-    const spec = toolsByName.WithValidationRPC_handleAll.outputSchema?.['~standard'];
+    const spec = handleAllTool.outputSchema?.['~standard'];
     assert.ok(spec);
     const output = { anything: true };
     assert.deepStrictEqual(await spec.validate(output), { value: output });
   });
 
   it('Keeps inputSchema and outputSchema undefined when the RPC method has no validation', () => {
-    const tool = toolsByName.OpenApiControllerRPC_openapi;
+    const tool = tools.find(({ name }) => name === 'OpenApiControllerRPC_openapi');
     assert.ok(tool, 'expected the tool to be derived');
     assert.strictEqual(tool.inputSchema, undefined);
     assert.strictEqual(tool.outputSchema, undefined);

--- a/test/src/common/derive-tools.test.ts
+++ b/test/src/common/derive-tools.test.ts
@@ -66,7 +66,7 @@ describe('deriveTools', () => {
       // ...
     });
 
-    const { tools, toolsByName } = deriveTools({
+    const tools = deriveTools({
       meta: { inputMeta: 'hello' },
       modules: {
         MyModule: {
@@ -91,35 +91,32 @@ describe('deriveTools', () => {
       unknown
     >[];
 
-    toolsByName satisfies {
-      [key: string]: StandardToolV0<
-        {
-          body?: unknown;
-          query?: unknown;
-          params?: unknown;
-        },
-        unknown,
-        unknown
-      >;
+    const getTool = (name: string) => {
+      const tool = tools.find((tool) => tool.name === name);
+      assert.ok(tool, `expected the "${name}" tool to be derived`);
+      return tool;
     };
 
     it('Should return tools', async () => {
       assert.equal(tools.length, 4);
-      assert.deepStrictEqual(Object.keys(toolsByName), [
-        'MyModule_procedureWithBody',
-        'MyModule_procedureWithToolDescription',
-        'customToolName',
-        'MyModule2_procedureWithQuery',
-      ]);
+      assert.deepStrictEqual(
+        tools.map(({ name }) => name),
+        [
+          'MyModule_procedureWithBody',
+          'MyModule_procedureWithToolDescription',
+          'customToolName',
+          'MyModule2_procedureWithQuery',
+        ]
+      );
     });
 
     it('Should provide outputSchema', async () => {
-      const tool = toolsByName.MyModule_procedureWithBody;
+      const tool = getTool('MyModule_procedureWithBody');
       assert.deepStrictEqual(tool.outputSchema, outputSchema);
     });
 
     it('Should provide a merged inputSchema (Standard Schema + Standard JSON Schema)', async () => {
-      const tool = toolsByName.MyModule_procedureWithBody;
+      const tool = getTool('MyModule_procedureWithBody');
       assert.ok(tool.inputSchema, 'expected merged inputSchema to be defined');
       assert.strictEqual(tool.inputSchema['~standard'].vendor, 'vovk');
       assert.strictEqual(tool.inputSchema['~standard'].version, 1);
@@ -133,7 +130,7 @@ describe('deriveTools', () => {
     });
 
     it('Should validate input', async () => {
-      const tool = toolsByName.MyModule_procedureWithBody;
+      const tool = getTool('MyModule_procedureWithBody');
       let result = await tool.execute({ body: { foo: 'foo1' } });
       assert.deepStrictEqual(result, { foo: 'foo1', inputMeta: 'hello' });
       result = await tool.execute({ body: { foo: 'foo1long' } });
@@ -143,16 +140,16 @@ describe('deriveTools', () => {
     });
 
     it('Should use proper description', async () => {
-      assert.strictEqual(toolsByName.MyModule_procedureWithBody.description, 'procedureWithBody description');
+      assert.strictEqual(getTool('MyModule_procedureWithBody').description, 'procedureWithBody description');
       assert.strictEqual(
-        toolsByName.MyModule_procedureWithToolDescription.description,
+        getTool('MyModule_procedureWithToolDescription').description,
         'procedureWithToolDescription x-tool-description'
       );
     });
   });
 
   describe('Explicit custom toModelOutput', () => {
-    const { tools, toolsByName } = deriveTools({
+    const tools = deriveTools({
       meta: { inputMeta: 'hello' },
       toModelOutput: async (result) => {
         if (result instanceof Error) {
@@ -174,20 +171,9 @@ describe('deriveTools', () => {
       unknown,
       { myResult?: unknown; myError?: string }
     >[];
-    toolsByName satisfies {
-      [key: string]: StandardToolV0<
-        {
-          body?: unknown;
-          query?: unknown;
-          params?: unknown;
-        },
-        unknown,
-        { myResult?: unknown; myError?: string }
-      >;
-    };
 
     it('Should validate input', async () => {
-      const tool = toolsByName.MyModule_procedureWithBody;
+      const [tool] = tools;
       let result = await tool.execute({ body: { foo: 'foo1' } });
       assert.deepStrictEqual(result, { myResult: { foo: 'foo1', inputMeta: 'hello' } });
       result = await tool.execute({ body: { foo: 'foo1long' } });
@@ -198,7 +184,7 @@ describe('deriveTools', () => {
   });
 
   describe('Explicit default toModelOutput = ToModelOutput.DEFAULT', () => {
-    const { tools, toolsByName } = deriveTools({
+    const tools = deriveTools({
       meta: { inputMeta: 'hello' },
       toModelOutput: ToModelOutput.DEFAULT,
       modules: {
@@ -218,25 +204,16 @@ describe('deriveTools', () => {
       unknown
     >[];
 
-    toolsByName satisfies {
-      [key: string]: StandardToolV0<
-        {
-          body?: unknown;
-          query?: unknown;
-          params?: unknown;
-        },
-        unknown,
-        unknown
-      >;
-    };
-
     it('Should return tools', async () => {
       assert.equal(tools.length, 1);
-      assert.deepStrictEqual(Object.keys(toolsByName), ['MyModule_procedureWithBody']);
+      assert.deepStrictEqual(
+        tools.map(({ name }) => name),
+        ['MyModule_procedureWithBody']
+      );
     });
 
     it('Should validate input', async () => {
-      const tool = toolsByName.MyModule_procedureWithBody;
+      const [tool] = tools;
       let result = await tool.execute({ body: { foo: 'foo1' } });
       assert.deepStrictEqual(result, { foo: 'foo1', inputMeta: 'hello' });
       result = await tool.execute({ body: { foo: 'foo1long' } });
@@ -248,7 +225,7 @@ describe('deriveTools', () => {
 
   describe('toModelOutput = ToModelOutput.MCP', () => {
     describe('Common, normal JSON output', () => {
-      const { tools, toolsByName } = deriveTools({
+      const tools = deriveTools({
         meta: { inputMeta: 'hello' },
         toModelOutput: ToModelOutput.MCP,
         modules: {
@@ -267,20 +244,8 @@ describe('deriveTools', () => {
         MCPModelOutput
       >[];
 
-      toolsByName satisfies {
-        [key: string]: StandardToolV0<
-          {
-            body?: unknown;
-            query?: unknown;
-            params?: unknown;
-          },
-          unknown,
-          MCPModelOutput
-        >;
-      };
-
       it('Should validate input', async () => {
-        const tool = toolsByName.MyModule_procedureWithBody;
+        const [tool] = tools;
         let result: MCPModelOutput = await tool.execute({ body: { foo: 'foo1' } });
         assert.deepStrictEqual(result, {
           content: [
@@ -312,13 +277,12 @@ describe('deriveTools', () => {
           return ['item1', 'item2', 'item3'];
         });
 
-        const { toolsByName } = deriveTools({
+        const [tool] = deriveTools({
           toModelOutput: ToModelOutput.MCP,
           modules: {
             MyModule: { arrayProcedure },
           },
         });
-        const tool = toolsByName.MyModule_arrayProcedure;
         const result: MCPModelOutput = await tool.execute({});
         assert.deepStrictEqual(result, {
           content: [
@@ -333,7 +297,7 @@ describe('deriveTools', () => {
     });
 
     describe('Audio Response instance', () => {
-      const { toolsByName } = deriveTools({
+      const [withAudioResponseTool] = deriveTools({
         toModelOutput: ToModelOutput.MCP,
         modules: {
           MyModule: {
@@ -353,7 +317,7 @@ describe('deriveTools', () => {
       });
 
       it('Should return audio output', async () => {
-        const result: MCPModelOutput = await toolsByName.withAudioResponse.execute({});
+        const result: MCPModelOutput = await withAudioResponseTool.execute({});
         assert.deepStrictEqual(result, {
           content: [
             {
@@ -368,7 +332,7 @@ describe('deriveTools', () => {
 
     describe('Image Response instance', () => {
       // 2x2 red PNG image
-      const { toolsByName } = deriveTools({
+      const [withImageResponseTool] = deriveTools({
         toModelOutput: ToModelOutput.MCP,
         modules: {
           MyModule: {
@@ -397,7 +361,7 @@ describe('deriveTools', () => {
       });
 
       it('Should return image output', async () => {
-        const result: MCPModelOutput = await toolsByName.withImageResponse.execute({});
+        const result: MCPModelOutput = await withImageResponseTool.execute({});
         assert.deepStrictEqual(result, {
           content: [
             {
@@ -413,7 +377,7 @@ describe('deriveTools', () => {
     describe('Image Response instance (fetch)', () => {
       const base64 = 'iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAADklEQVQI12P4z8AAAAEBAQAY3Y20AAAAAElFTkSuQmCC';
 
-      const { toolsByName } = deriveTools({
+      const [withImageResponseTool] = deriveTools({
         toModelOutput: ToModelOutput.MCP,
         modules: {
           MyModule: {
@@ -430,7 +394,7 @@ describe('deriveTools', () => {
       });
 
       it('Should return fetched image output', async () => {
-        const result: MCPModelOutput = await toolsByName.withImageResponse.execute({});
+        const result: MCPModelOutput = await withImageResponseTool.execute({});
         assert.deepStrictEqual(result, {
           content: [
             {
@@ -444,7 +408,7 @@ describe('deriveTools', () => {
     });
 
     describe('CSV Response instance', () => {
-      const { toolsByName } = deriveTools({
+      const [withCSVResponseTool] = deriveTools({
         toModelOutput: ToModelOutput.MCP,
         modules: {
           MyModule: {
@@ -465,7 +429,7 @@ describe('deriveTools', () => {
       });
 
       it('Should return CSV output', async () => {
-        const result: MCPModelOutput = await toolsByName.withCSVResponse.execute({});
+        const result: MCPModelOutput = await withCSVResponseTool.execute({});
         assert.deepStrictEqual(result, {
           content: [
             {
@@ -478,7 +442,7 @@ describe('deriveTools', () => {
     });
 
     describe('Text Response instance', () => {
-      const { toolsByName } = deriveTools({
+      const [withTextResponseTool] = deriveTools({
         toModelOutput: ToModelOutput.MCP,
         modules: {
           MyModule: {
@@ -497,7 +461,7 @@ describe('deriveTools', () => {
       });
 
       it('Should return text output', async () => {
-        const result: MCPModelOutput = await toolsByName.withTextResponse.execute({});
+        const result: MCPModelOutput = await withTextResponseTool.execute({});
         assert.deepStrictEqual(result, {
           content: [
             {
@@ -510,7 +474,7 @@ describe('deriveTools', () => {
     });
 
     describe('JSON Response instance', () => {
-      const { toolsByName } = deriveTools({
+      const [withJSONResponseTool] = deriveTools({
         toModelOutput: ToModelOutput.MCP,
         modules: {
           MyModule: {
@@ -529,7 +493,7 @@ describe('deriveTools', () => {
       });
 
       it('Should return JSON MCPModelOutput', async () => {
-        const result: MCPModelOutput = await toolsByName.withJSONResponse.execute({});
+        const result: MCPModelOutput = await withJSONResponseTool.execute({});
         assert.deepStrictEqual(result, {
           content: [
             {
@@ -558,7 +522,7 @@ describe('deriveTools', () => {
         return { foo };
       });
 
-      const { toolsByName } = deriveTools({
+      const [procedureWithAnnotationsTool] = deriveTools({
         toModelOutput: ToModelOutput.MCP,
         modules: {
           MyModule: {
@@ -567,7 +531,7 @@ describe('deriveTools', () => {
         },
       });
 
-      const result: MCPModelOutput = await toolsByName.procedureWithAnnotations.execute({ body: { foo: 'bar' } });
+      const result: MCPModelOutput = await procedureWithAnnotationsTool.execute({ body: { foo: 'bar' } });
       assert.deepStrictEqual(result, {
         content: [
           {
@@ -582,7 +546,7 @@ describe('deriveTools', () => {
   });
 
   describe('Custom Result Formatter', () => {
-    const { tools, toolsByName } = deriveTools({
+    const tools = deriveTools({
       meta: { inputMeta: 'hello' },
       toModelOutput: async (result) => {
         if (result instanceof Error) {
@@ -605,20 +569,8 @@ describe('deriveTools', () => {
       { myResult?: unknown; myError?: string }
     >[];
 
-    toolsByName satisfies {
-      [key: string]: StandardToolV0<
-        {
-          body?: unknown;
-          query?: unknown;
-          params?: unknown;
-        },
-        unknown,
-        { myResult?: unknown; myError?: string }
-      >;
-    };
-
     it('Should validate input', async () => {
-      const tool = toolsByName.MyModule_procedureWithBody;
+      const [tool] = tools;
       let result = await tool.execute({ body: { foo: 'foo1' } });
       assert.deepStrictEqual(result, { myResult: { foo: 'foo1', inputMeta: 'hello' } });
       result = await tool.execute({ body: { foo: 'foo1long' } });
@@ -640,19 +592,25 @@ describe('deriveTools', () => {
       params: paramsSchema,
     }).handle(async () => ({ ok: true }));
 
-    const { toolsByName } = deriveTools({
+    const tools = deriveTools({
       modules: {
         MyModule: { procedureWithNoSlots, procedureWithAllSlots },
       },
     });
 
+    const getTool = (name: string) => {
+      const tool = tools.find((tool) => tool.name === name);
+      assert.ok(tool, `expected the "${name}" tool to be derived`);
+      return tool;
+    };
+
     it('Should leave inputSchema undefined when the procedure has no body/query/params', () => {
-      const tool = toolsByName.MyModule_procedureWithNoSlots;
+      const tool = getTool('MyModule_procedureWithNoSlots');
       assert.strictEqual(tool.inputSchema, undefined);
     });
 
     it('Merged inputSchema produces the expected JSON Schema envelope', () => {
-      const tool = toolsByName.MyModule_procedureWithAllSlots;
+      const tool = getTool('MyModule_procedureWithAllSlots');
       assert.ok(tool.inputSchema);
       const jsonSchema = tool.inputSchema['~standard'].jsonSchema.input({ target: 'draft-2020-12' });
       assert.strictEqual(jsonSchema.type, 'object');
@@ -665,7 +623,7 @@ describe('deriveTools', () => {
     });
 
     it('Merged inputSchema validates all three slots together', async () => {
-      const tool = toolsByName.MyModule_procedureWithAllSlots;
+      const tool = getTool('MyModule_procedureWithAllSlots');
       assert.ok(tool.inputSchema);
       const okResult = await tool.inputSchema['~standard'].validate({
         body: { foo: 'a' },


### PR DESCRIPTION
## Summary

- `deriveTools` now returns the tools array directly instead of `{ tools, toolsByName }`
- `DeriveToolsResult` type removed
- Tests updated: single-tool suites destructure `const [tool] = tools`; multi-tool suites use a `getTool(name)` helper over `tools.find()`

Breaking change for v4. Lookup by name is a one-liner (`tools.find((t) => t.name === name)` or `Object.fromEntries(tools.map((t) => [t.name, t]))`), so the extra return shape wasn't pulling its weight against the standard-tool convention of plain tool arrays.